### PR TITLE
Reconsider how we get types safely to Python ready 

### DIFF
--- a/.github/workflows/rt4core-concurrencyTest.yml
+++ b/.github/workflows/rt4core-concurrencyTest.yml
@@ -11,7 +11,7 @@ permissions:
     contents: read
 
 jobs:
-  rt4-unit-tests-Ubuntu-jdk-17:
+  rt4-unit-tests-Ubuntu-jdk-17-arm:
 
     runs-on: ubuntu-24.04-arm
 

--- a/.github/workflows/rt4core-concurrencyTest.yml
+++ b/.github/workflows/rt4core-concurrencyTest.yml
@@ -1,0 +1,37 @@
+# Run concurrency unit tests on ARM in rt4 core sub-project (GitHub action)
+name: rt4 core unit tests (ARM)
+
+# The ARM memory model is weaker than the Intel-amd64 model.
+# A correctly synchronised program should always run identically.
+# An incorrectly synchronised one may exhibit different failures.
+
+on: [push]
+
+permissions:
+    contents: read
+
+jobs:
+  rt4-unit-tests-Ubuntu-jdk-17:
+
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - run: echo "Branch ${{ github.ref }} of repository ${{ github.repository }}."
+      - uses: actions/checkout@v4
+
+      - uses: gradle/actions/wrapper-validation@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          # This has to match the language version we're targeting
+          python-version: '3.11'
+
+      - name: Unit test with Gradle
+        run: ./gradlew --no-daemon rt4core:concurrencyTest

--- a/rt4core/config/concurrencyTest.logging.properties
+++ b/rt4core/config/concurrencyTest.logging.properties
@@ -1,0 +1,78 @@
+# rt4core:kernelTest Logging Configuration File
+#
+# This file is adapted from kernelTest.logging.properties.
+# It greatly reduces the logging output for concurrency tests,
+# which tend to have many duplicate activities, so that log output
+# does not slow the test down (or drown the reader).
+#
+# How to use this configuration file
+# ----------------------------------
+# Specify this configuration in a Gradle test suite, in our case at
+#     testing.suites.concurrencyTest . targets.all . testTest.configure
+# with:
+#
+# systemProperty(
+#     'java.util.logging.config.file',
+#     getProject().file('config/concurrencyTest.logging.properties'))
+#
+# Specify this configuration in the Eclipse IDE with JVM argument:
+# -Djava.util.logging.config.file=${workspace_loc:/rt4core}/config/concurrencyTest.logging.properties
+# If we need to debug a concurrency test, we can turn logging back on 
+# by choosing one of the verbose configurations we normally use like:
+# -Djava.util.logging.config.file=${workspace_loc:/rt4core}/config/kernelTest.logging.properties
+
+
+############################################################
+# Global properties
+############################################################
+
+# A comma-separated list of log Handler classes:
+#handlers= java.util.logging.ConsoleHandler, java.util.logging.FileHandler
+handlers= java.util.logging.ConsoleHandler
+
+# Default global logging level. For any given facility this global level
+# can be overridden by a facility-specific level.
+.level= INFO
+
+
+############################################################
+# Handler specific properties.
+############################################################
+
+# ConsoleHandler
+# --------------
+
+# Allow to be verbose (FINEST) and control at facility level.
+java.util.logging.ConsoleHandler.level = FINEST
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+# Customise the SimpleFormatter output format
+#java.util.logging.SimpleFormatter.format=%1$tH:%1$tM:%1$tS.%1$tL %4$s (%3$s) %5$s%n
+java.util.logging.SimpleFormatter.format=%1$tH:%1$tM:%1$tS %4$s (%3$s) %5$s%n
+
+
+# FileHandler
+# -----------
+
+# default file output is in user's home directory.
+java.util.logging.FileHandler.pattern = %h/java%u.log
+java.util.logging.FileHandler.limit = 50000
+java.util.logging.FileHandler.count = 1
+# Default number of locks FileHandler can obtain synchronously.
+java.util.logging.FileHandler.maxLocks = 100
+java.util.logging.FileHandler.formatter = java.util.logging.XMLFormatter
+
+
+############################################################
+# Facility-specific properties.
+############################################################
+
+# SLF4J decoder: error->SEVERE, warn->WARNING, info->INFO,
+#                debug->FINE, trace->FINEST 
+
+# Levels chosen depend on what we're interested in at the moment.
+# The default .level above will step in if a logger is not mentioned.
+uk.co.farowl.vsj4.runtime.level = INFO
+#uk.co.farowl.vsj4.runtime.kernel.level = FINEST
+#uk.co.farowl.vsj4.runtime.kernel.SpecialMethod.level = FINE
+#org.junit.level = CONFIG

--- a/rt4core/rt4core.gradle
+++ b/rt4core/rt4core.gradle
@@ -33,7 +33,11 @@ dependencies {
 }
 
 
-// Configure the jvm-test-suite plug-in
+/* Configure the jvm-test-suite plug-in
+ *
+ * We follow the Gradle 8.8 notes on the JVM Test Suite Plugin.
+ * and the example of configuring integration tests.
+ */
 testing {
     suites {
         // The pre-defined test suite.
@@ -58,9 +62,35 @@ testing {
         }
 
         /*
+         * A test suite for tests with many concurrent threads. Logging
+         * is minimised to prevent slowness, repetition, and accidental
+         * synchronisation.
+         */
+        concurrencyTest(JvmTestSuite) {
+            useJUnitJupiter()
+
+            dependencies {
+                implementation project()
+                implementation 'org.slf4j:slf4j-api:2.0.13'
+                // Include a logging provider (JDK 1.4)
+                runtimeOnly 'org.slf4j:slf4j-jdk14:2.0.13'
+            }
+
+            targets {
+                all {
+                    testTask.configure {
+                        // Log output is minimised with this config:
+                        systemProperty(
+                            'java.util.logging.config.file',
+                            getProject().file('config/concurrencyTest.logging.properties') )
+                        testLogging.showStandardStreams = true
+                    }
+                }
+            }
+        }
+
+        /*
          * A test suite where each test runs in its own JVM.
-         * We follow the Gradle 8.8 notes on the JVM Test Suite Plugin.
-         * and the example of configuring integration tests.
          */
         kernelTest(JvmTestSuite) {
             useJUnitJupiter()
@@ -92,11 +122,12 @@ testing {
     }
 }
 
-test.dependsOn(kernelTest)
+test.dependsOn(kernelTest, concurrencyTest)
 
 
 tasks.named('check') { 
     dependsOn(testing.suites.kernelTest)
+    dependsOn(testing.suites.concurrencyTest)
 }
 
 
@@ -315,7 +346,8 @@ task testJavadoc(type:Javadoc,
         description: 'Generate Javadoc for tests',
         dependsOn: internalJavadoc) {
 
-    source(sourceSets.test.allJava, sourceSets.kernelTest.allJava)
+    source(sourceSets.test.allJava, sourceSets.kernelTest.allJava,
+            sourceSets.concurrencyTest.allJava)
     title = "rt4core Unit Tests"
     destinationDir = file("${buildDir}/docs/testJavadoc")
 

--- a/rt4core/src/concurrencyTest/java/uk/co/farowl/vsj4/runtime/TypeConcurrencyTest.java
+++ b/rt4core/src/concurrencyTest/java/uk/co/farowl/vsj4/runtime/TypeConcurrencyTest.java
@@ -55,10 +55,10 @@ class TypeConcurrencyTest {
             LoggerFactory.getLogger(TypeConcurrencyTest.class);
 
     /** Threads in each batch. */
-    static final int BATCH_SIZE = 20; // ~100
+    static final int BATCH_SIZE = 25; // ~ 10s
 
     /** Number of batches. */
-    static final int BATCH_COUNT = 100; // ~ 10000
+    static final int BATCH_COUNT = 1000; // ~ 1000s
 
     /** Curtail the test when we have found this many failures. */
     static final int FAILURE_LIMIT = BATCH_SIZE + 5;
@@ -89,7 +89,7 @@ class TypeConcurrencyTest {
             tests[i] = new SBLitmusTest();
         }
 
-        logger.debug("TypeConcurrencyTest begun");
+        logger.info("TypeConcurrencyTest begun");
 
         // We use that storage repeatedly with new tests.
         for (int batch = 0; batch < BATCH_COUNT; batch++) {
@@ -129,7 +129,7 @@ class TypeConcurrencyTest {
 
     @AfterAll
     static void tearDownClass() {
-        logger.debug("TypeConcurrencyTest complete");
+        logger.info("TypeConcurrencyTest complete");
     }
 
     private static boolean hasStopped(Thread t) {

--- a/rt4core/src/concurrencyTest/java/uk/co/farowl/vsj4/runtime/TypeConcurrencyTest.java
+++ b/rt4core/src/concurrencyTest/java/uk/co/farowl/vsj4/runtime/TypeConcurrencyTest.java
@@ -6,14 +6,17 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CyclicBarrier;
+import java.util.function.Supplier;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
@@ -22,23 +25,24 @@ import org.slf4j.LoggerFactory;
 /**
  * This test modifies the attributes of some (mutable) type objects and
  * reads those attributes, or performs operations dependent on them,
- * concurrently from distinct threads. It will look for (and fail on)
- * outcomes we deem impossible.
+ * concurrently from distinct threads. It is a collection of nested
+ * tests. Each will look for (and fail on) outcomes we deem impossible.
  * <p>
  * Unusually for JUnit tests, the intense processing takes place during
- * {@link #setUpClass()}, and the individual JUnit tests are predicates
- * on a list of lists of violations collected on during that time. If
- * the list is empty, that's a pass.
+ * the static initialisation method (annotated &#64;{@link BeforeAll})
+ * of each test, during which we collect a list of violations. The
+ * individual JUnit tests are predicates on that list. If the list is
+ * empty, that's a pass.
  * <p>
- * A significant conceptual challenge is to define the expected or
- * disallowed behaviours. Python has only recently started to allow true
- * concurrency without the GIL and the required behaviours are not yet
- * clearly stated (2025). Java guarantees "sequentially consistent"
- * execution of correctly synchronised programs. The tests here are
- * (deliberately) <b>not</b> correctly synchronised in the test region.
- * The hypothesis we attempt to disprove by testing is that
- * unsynchronised use from Python of the objects we provide leads to
- * behaviour not expected of Python.
+ * Java guarantees "sequentially consistent" execution of correctly
+ * synchronised programs, but the tests here are (deliberately)
+ * <b>not</b> correctly synchronised. The hypothesis we attempt to
+ * disprove by testing is that unsynchronised use of Python objects we
+ * provide leads to behaviour not expected of Python.
+ * <p>
+ * It is challenging to define the allowed or forbidden outcomes. Python
+ * has only recently started to allow true concurrency without the GIL
+ * and the required behaviours are not yet clearly stated (2025).
  * <p>
  * This test is influenced by the literature on the "litmus tests", used
  * to test or complement assertions made for a processor architecture
@@ -46,133 +50,34 @@ import org.slf4j.LoggerFactory;
  * Concurrency in Practice</i>, Peierls, Goetz, et al. is an example of
  * the latter.
  */
-@DisplayName("When multiple threads access type objects")
+@DisplayName("During concurrent use of type objects ...")
 @TestMethodOrder(MethodOrderer.MethodName.class)
 class TypeConcurrencyTest {
 
-    /** Logger for the test. */
+    /** Logger for the tests. */
     static final Logger logger =
             LoggerFactory.getLogger(TypeConcurrencyTest.class);
 
     /** Threads in each batch. */
-    static final int BATCH_SIZE = 25; // ~ 10s
+    static final int BATCH_SIZE = 5; // ~ 10s
 
     /** Number of batches. */
-    static final int BATCH_COUNT = 1000; // ~ 1000s
+    static final int BATCH_COUNT = 3; // ~ 1000s
 
-    /** Curtail the test when we have found this many failures. */
+    /** Curtail a test once we have found this many failures. */
     static final int FAILURE_LIMIT = BATCH_SIZE + 5;
 
-    /** Failing litmus tests */
-    static List<LitmusTest> failures = new LinkedList<>();
-
     /**
-     * We create multiple threads for each behavioural sequence and run
-     * them concurrently. They will make observations of the types that
-     * ought only to be possible definitely after each is Python-ready.
-     * Each will note the high-resolution time at which it began and was
-     * able to complete its first action, and complete its other
-     * actions.
-     */
-    @BeforeAll
-    static void setUpClass() throws Throwable {
-
-        // Ensure the type system exists
-        assertTrue(TypeSystem.bootstrapNanoTime > 0L,
-                "Check type system booted");
-
-        // Batch of tests to run concurrently.
-        LitmusTest[] tests = new LitmusTest[BATCH_SIZE];
-        Thread[] threads = new Thread[BATCH_SIZE];
-
-        for (int i = 0; i < BATCH_SIZE; i++) {
-            tests[i] = new SBLitmusTest();
-        }
-
-        logger.info("TypeConcurrencyTest begun");
-
-        // We use that storage repeatedly with new tests.
-        for (int batch = 0; batch < BATCH_COUNT; batch++) {
-            // Create threads: each will run a pair of racing threads.
-            for (int i = 0; i < BATCH_SIZE; i++) {
-                threads[i] = new Thread(tests[i]);
-            }
-            // Start them all close together in time
-            for (Thread t : threads) { t.start(); }
-
-            // Wait for the threads to finish.
-            for (int i = 0; i < BATCH_SIZE; i++) {
-                try {
-                    threads[i].join(1000);
-                } catch (InterruptedException e) {
-                    // Check completion later
-                }
-                // Collect failures in a list.
-                LitmusTest test = tests[i];
-                if (test.failed()) {
-                    failures.add(test);
-                    tests[i] = new SBLitmusTest();
-                } else {
-                    test.reset();
-                }
-            }
-
-            // Make sure they all stop (so the test does).
-            boolean allStopped = true;
-            for (Thread t : threads) { allStopped &= hasStopped(t); }
-            assertTrue(allStopped, "Threads were still running");
-
-            // Early exit if ample evidence.
-            if (failures.size() >= FAILURE_LIMIT) { break; }
-        }
-    }
-
-    @AfterAll
-    static void tearDownClass() {
-        logger.info("TypeConcurrencyTest complete");
-    }
-
-    private static boolean hasStopped(Thread t) {
-        if (t.isAlive()) {
-            logger.warn("Still running {}", t.getName());
-            return false;
-        }
-        return true;
-    }
-
-    /** Check for tests that ended with an exceptions. */
-    @SuppressWarnings("static-method")
-    @Test
-    @DisplayName("No exceptions were thrown")
-    void checkException() {
-        for (LitmusTest t : failures) {
-            assertNull(t.exc1,
-                    () -> String.format("thread t1 threw %s", t.exc1));
-            assertNull(t.exc2,
-                    () -> String.format("thread t2 threw %s", t.exc2));
-        }
-    }
-
-    /** Check the outcome was allowed. */
-    @SuppressWarnings("static-method")
-    @Test
-    @DisplayName("Only allowed states were reached")
-    void checkAllowed() throws PyAttributeError, Throwable {
-        for (LitmusTest t : failures) {
-            if (!t.allowed()) { fail(t.toString()); }
-        }
-    }
-
-    /**
-     * A test object that runs two threads defined by the methods
+     * A test fixture that runs two threads defined by the methods
      * {@link #t1()} and {@link #t2()} in a race. The test object itself
      * implements {@link Runnable} so that we can run many copies in
      * parallel (for efficiency and to stress the processor), but it is
-     * the pair of threads in each case that constitute the test, or the
-     * effective litmus test {@code program}.
+     * the pair of threads in each case that constitute the effective
+     * "litmus test program".
      * <p>
-     * A subclass defines {@link #t1()}, {@link #t2()} and
-     * {@link #allowed()} to define the activity and determine whether
+     * In order to use this class, a subclass defines {@link #t1()} and
+     * {@link #t2()} to define the activity, and {@link #allowed()} or
+     * {@link #forbidden()} (not usually both) to and determine whether
      * the outcome is allowed (a pass) for not (a fail).
      */
     abstract static class LitmusTest implements Runnable {
@@ -190,26 +95,32 @@ class TypeConcurrencyTest {
 
         /**
          * Test whether the result of the pair of threads is allowed
-         * behaviour (a pass) for not (a fail).
-         */
-        abstract boolean allowed();
-
-        /**
-         * Create a test consisting of two threads ready to be started,
-         * one to call {@link #t1()} and the other {@link #t2()}. When
-         * started by <code>this.{@link #run()}</code>, both threads
-         * wait at a barrier of capacity two, meaning the first waits
-         * and until the second arrives there, then both proceed to call
-         * their respective methods in a race. Afterwards,
-         * {@link #allowed()} determines whether the state reached is an
-         * allowed one.
-         */
-        LitmusTest() {}
-
-        /**
-         * Run the two threads set up by the constructor and wait for
-         * both to complete.
+         * behaviour (a pass) or not (a fail). Returns {@code true} by
+         * default.
          *
+         * @return {@code false} if a fail
+         */
+        @SuppressWarnings("static-method")
+        boolean allowed() { return true; }
+
+        /**
+         * Test whether the result of the pair of threads is forbidden
+         * behaviour (a fail) or not (a pass). Returns {@code false} by
+         * default.
+         *
+         * @return {@code true} if a fail
+         */
+        @SuppressWarnings("static-method")
+        boolean forbidden() { return false; }
+
+        /**
+         * Create and run two threads, one to call {@link #t1()} and the
+         * other {@link #t2()}. Both threads wait at a barrier of
+         * capacity two, meaning the first waits until the second
+         * arrives there, then both proceed to call their respective
+         * methods in a race. Afterwards, {@link #allowed()} (must be
+         * {@code true}) {@link #forbidden()} (must be {@code false})
+         * determine whether the state reached is permitted.
          */
         @Override
         public void run() {
@@ -250,59 +161,182 @@ class TypeConcurrencyTest {
         }
 
         /**
-         * Return true if there was an exception of allowed is false.
+         * Return {@code true} if there was an exception during
+         * {@link #t1()} or {@link #t2()}, if {@link #allowed()} is
+         * {@code false} or if {@link #forbidden()} is {@code true}.
+         *
+         * @return {@code true} on failure
          */
         boolean failed() {
-            return exc1 != null || exc2 != null || !allowed();
+            return exc1 != null || exc2 != null || !allowed()
+                    || forbidden();
         }
 
         /**
          * Return the test to initial conditions to save creating a
-         * fresh one. Only define this if that can be validly done.
+         * fresh one. Only re-define this if that can be validly done,
+         * in which case it should return {@code true}. The default
+         * return value is {@code false}, which indicates to the caller
+         * it should create a new test object.
          */
         @SuppressWarnings("static-method")
-        void reset() { fail("reset() not supported"); }
+        boolean reset() { return false; }
     }
 
     /**
-     * The Storage Buffering litmus test interpreted for a type object
-     * name space as the "store". We add attributes in a race and test
-     * for a sequentially consistent result.
-     * <p>
-     * The test shows that the updates to a type object are published
-     * between threads as if execution were sequentially consistent.
+     * A base class for tests that run multiple litmus tests in parallel
+     * and examine the outcomes.
      */
-    static class SBLitmusTest extends LitmusTest {
+    abstract static class Examination {
+
+        /** Failing litmus tests */
+        List<? extends LitmusTest> failures = new LinkedList<>();
+
+        /**
+         * This method must be called from the static set-up of each
+         * (annotated &#64;{@link BeforeAll}) individual test class, and
+         * the returned list be in the (instance) field {@code failures}
+         * by a &#64;{@link BeforeEach} method. It is given a factory
+         * method ({@code new}) for a litmus test object of the specific
+         * kind needed by the test.
+         * <p>
+         * This is the method that performs most of the work. It returns
+         * a list of failing cases (as determined by
+         * {@link LitmusTest#failed()}).
+         *
+         * @param <T> Specific type of litmus test
+         * @param newInstance new method of that type (or factory)
+         * @return instances where LitmusTest#failed
+         * @throws Throwable on uncaught errors (not failed tests)
+         */
+        static <T extends LitmusTest> List<T>
+                race(Supplier<T> newInstance) throws Throwable {
+
+            // Failing litmus tests
+            List<T> failures = new LinkedList<>();
+
+            // Ensure the type system exists
+            assertTrue(TypeSystem.bootstrapNanoTime > 0L,
+                    "Check type system booted");
+
+            // Batch of tests to run concurrently.
+            ArrayList<T> tests = new ArrayList<>(BATCH_SIZE);
+            Thread[] threads = new Thread[BATCH_SIZE];
+
+            for (int i = 0; i < BATCH_SIZE; i++) {
+                tests.add(i, newInstance.get());
+            }
+            String name = tests.get(0).getClass().getCanonicalName();
+
+            logger.atInfo().setMessage("Race begun ({})")
+                    .addArgument(name).log();
+
+            // We use that storage repeatedly with new tests.
+            for (int batch = 0; batch < BATCH_COUNT; batch++) {
+                // Create threads: each will run a pair of racing
+                // threads.
+                for (int i = 0; i < BATCH_SIZE; i++) {
+                    threads[i] = new Thread(tests.get(i));
+                }
+                // Start them all close together in time
+                for (Thread t : threads) { t.start(); }
+
+                // Wait for the threads to finish.
+                for (int i = 0; i < BATCH_SIZE; i++) {
+                    try {
+                        threads[i].join(1000);
+                    } catch (InterruptedException e) {
+                        // Check completion later
+                    }
+                    // Collect failures in a list.
+                    T test = tests.get(i);
+                    if (test.failed()) {
+                        // Collect failed example and replace in tests.
+                        failures.add(test);
+                        tests.add(i, newInstance.get());
+                    } else if (!test.reset()) {
+                        // We could not reset the test object.
+                        tests.add(i, newInstance.get());
+                    }
+                }
+
+                // Make sure they all stop (so the test does).
+                boolean allStopped = true;
+                for (Thread t : threads) {
+                    allStopped &= hasStopped(t);
+                }
+                assertTrue(allStopped, "Threads were still running");
+
+                // Early exit if ample evidence.
+                if (failures.size() >= FAILURE_LIMIT) { break; }
+            }
+            logger.atInfo().setMessage("Race ended").addArgument(name)
+                    .log();
+
+            return failures;
+        }
+
+        /**
+         * Publish failing litmus tests to this test instance.
+         *
+         * @param failures resulting from the racing threads
+         */
+        void setFailures(List<? extends LitmusTest> failures) {
+            this.failures = failures;
+        }
+
+        private static boolean hasStopped(Thread t) {
+            if (t.isAlive()) {
+                logger.warn("Still running {}", t.getName());
+                return false;
+            }
+            return true;
+        }
+
+        /** Check for tests that ended with an exceptions. */
+        @Test
+        @DisplayName("No exceptions were thrown")
+        void checkException() {
+            for (LitmusTest t : failures) {
+                assertNull(t.exc1, () -> String
+                        .format("thread t1 threw %s", t.exc1));
+                assertNull(t.exc2, () -> String
+                        .format("thread t2 threw %s", t.exc2));
+            }
+        }
+
+        /** Check the outcome was allowed. */
+        @Test
+        @DisplayName("Only allowed states were reached")
+        void checkAllowed() throws PyAttributeError, Throwable {
+            for (LitmusTest t : failures) {
+                if (!t.allowed()) { fail(t.toString()); }
+            }
+        }
+    }
+
+    /**
+     * Extend {@link LitmusTest} for a single type object name space as
+     * the "store". The subclass should add attributes "A" and "B" in a
+     * race and expect a sequentially consistent result.
+     */
+    static abstract class SingleTypeLitmusTest extends LitmusTest {
+        /** Type object to use as a namespace. */
         PyType type;
+        /** Variables set by the racing threads (registers). */
         Object r1, r2;
 
-        SBLitmusTest() throws Throwable {
-            this.type = (PyType)PyType.TYPE().call("SBType",
-                    Py.tuple(PyObject.TYPE), Py.dict());
+        SingleTypeLitmusTest() {
+            try {
+                this.type = (PyType)PyType.TYPE().call("LitmusTestType",
+                        Py.tuple(PyObject.TYPE), Py.dict());
+            } catch (Throwable e) {
+                fail("Constructing an instance");
+            }
         }
 
         @Override
-        void t1() throws Throwable {
-            r1 = Abstract.lookupAttr(type, "A");
-            Abstract.setAttr(type, "B", 2);
-        }
-
-        @Override
-        void t2() throws Throwable {
-            r2 = Abstract.lookupAttr(type, "B");
-            Abstract.setAttr(type, "A", 1);
-        }
-
-        @Override
-        boolean allowed() {
-            // Sequentially consistent answer.
-            return r1 == null && r2 == null  //
-                    || r1 == null && r2.equals(2)  //
-                    || r1.equals(1) && r2 == null;
-        }
-
-        @Override
-        void reset() {
+        boolean reset() {
             r1 = r2 = null;
             exc1 = exc2 = null;
             try {
@@ -315,12 +349,110 @@ class TypeConcurrencyTest {
             } catch (Throwable e) {
                 fail("Unable to reset() type attributes");
             }
+            return true;
         }
 
         @Override
         public String toString() {
-            return String.format("SBLitmusTest [type=%s, r1=%s, r2=%s]",
-                    type, r1, r2);
+            return String.format("[type=%s, r1=%s, r2=%s]", type, r1,
+                    r2);
+        }
+    }
+
+    /**
+     * The Load Buffering litmus test interpreted for a single type
+     * object name space as the "store". We add attributes in a race and
+     * expect a sequentially consistent result.
+     */
+    @Nested
+    @DisplayName("Load Buffering (LB) single type")
+    class SingleTypeLB extends Examination {
+
+        /** Failing litmus tests */
+        static List<? extends LitmusTest> failures;
+
+        /** Run the set-up and collect failing cases. */
+        @BeforeAll
+        static void setUpClass() throws Throwable {
+            failures = Examination.race(Litmus::new);
+        }
+
+        @BeforeEach
+        void getFailures() { setFailures(failures); }
+
+        /**
+         * Define LB for type object name space as the "store". We add
+         * attributes in a race and expect a sequentially consistent
+         * result.
+         */
+        static class Litmus extends SingleTypeLitmusTest {
+
+            @Override
+            void t1() throws Throwable {
+                r1 = Abstract.lookupAttr(type, "A");
+                Abstract.setAttr(type, "B", 2);
+            }
+
+            @Override
+            void t2() throws Throwable {
+                r2 = Abstract.lookupAttr(type, "B");
+                Abstract.setAttr(type, "A", 1);
+            }
+
+            @Override
+            boolean allowed() {
+                // Sequentially consistent answer.
+                return r1 == null && r2 == null  //
+                        || r1 == null && r2.equals(2)  //
+                        || r1.equals(1) && r2 == null;
+            }
+        }
+    }
+
+    /**
+     * The Storage Buffering litmus test interpreted for a single type
+     * object name space as the "store". We add attributes in a race and
+     * expect a sequentially consistent result.
+     */
+    @Nested
+    @DisplayName("Store Buffering (SB) single type")
+    class SingleTypeSB extends Examination {
+
+        /** Failing litmus tests */
+        static List<? extends LitmusTest> failures;
+
+        /** Run the set-up and collect failing cases. */
+        @BeforeAll
+        static void setUpClass() throws Throwable {
+            failures = Examination.race(Litmus::new);
+        }
+
+        @BeforeEach
+        void getFailures() { setFailures(failures); }
+
+        /**
+         * Define SB for a type object name space as the "store". We add
+         * attributes in a race and expect a sequentially consistent
+         * result.
+         */
+        static class Litmus extends SingleTypeLitmusTest {
+            @Override
+            void t1() throws Throwable {
+                Abstract.setAttr(type, "B", 2);
+                r1 = Abstract.lookupAttr(type, "A");
+            }
+
+            @Override
+            void t2() throws Throwable {
+                Abstract.setAttr(type, "A", 1);
+                r2 = Abstract.lookupAttr(type, "B");
+            }
+
+            @Override
+            boolean forbidden() {
+                // Sequentially consistent answer.
+                return r1 == null && r2 == null;
+            }
         }
     }
 }

--- a/rt4core/src/concurrencyTest/java/uk/co/farowl/vsj4/runtime/TypeConcurrencyTest.java
+++ b/rt4core/src/concurrencyTest/java/uk/co/farowl/vsj4/runtime/TypeConcurrencyTest.java
@@ -780,14 +780,14 @@ class TypeConcurrencyTest {
             }
 
             @Override
-            boolean forbidden() {
+            boolean allowed() {
                 // Did r1 see the modified __neg__?
                 if (pythonEquals(42, r1)) {
                     // Then r2 must see the modified __str__.
                     return pythonEquals("forty-two", r2);
                 }
                 // Otherwise ok
-                return false;
+                return true;
             }
         }
     }
@@ -804,7 +804,7 @@ class TypeConcurrencyTest {
      */
     static boolean pythonEquals(Object x, Object o) {
         try {
-                return Abstract.richCompareBool(x, o, Comparison.EQ);
+            return Abstract.richCompareBool(x, o, Comparison.EQ);
         } catch (RuntimeException | Error e) {
             // Let unchecked exception fly
             throw e;

--- a/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/BootstrapTest.java
+++ b/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/BootstrapTest.java
@@ -159,7 +159,7 @@ class BootstrapTest {
                 return Long.compare(t1.firstNanoTime, t2.firstNanoTime);
             }
         };
-        String fmt = "           PyType.ready=%10d  (relative)\n";
+        String fmt = "Type system ready at   =%10d  (relative)\n";
         System.out.printf(fmt, TypeSystem.readyNanoTime
                 - TypeSystem.bootstrapNanoTime);
         Collections.sort(threads, byFirst);

--- a/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/BootstrapTest.java
+++ b/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/BootstrapTest.java
@@ -71,8 +71,15 @@ class BootstrapTest {
     static final String DUMP_PROPERTY =
             "uk.co.farowl.vsj4.runtime.BootstrapTest.times";
 
-    /** Threads of each kind. */
-    static final int NTHREADS = 100; // suggest at least 15
+    /** Threads in total. &gt;&gt; {@code setUpClass()} cases. */
+    static final int NTHREADS = 100;
+    /**
+     * Check this many threads actually concurrent. Ideally
+     * &gt;{@code setUpClass()} cases but expectation depends on CPU.
+     */
+    static int MIN_THREADS =
+            Math.min(Runtime.getRuntime().availableProcessors(), 20);
+
     /** Threads to run. */
     static final List<InitThread> threads = new ArrayList<>();
     /** A barrier they all wait behind. */
@@ -193,7 +200,8 @@ class BootstrapTest {
         long competitors = threads.stream()
                 .filter(t -> t.startNanoTime <= 0L).count();
         logger.info("{} threads were racing.", competitors);
-        assertTrue(competitors > 10L, () -> String
+        logger.info("Required at least {} racing.", MIN_THREADS);
+        assertTrue(competitors > MIN_THREADS, () -> String
                 .format("Only %d competitors.", competitors));
     }
 

--- a/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/BootstrapTest.java
+++ b/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/BootstrapTest.java
@@ -2,11 +2,7 @@
 // Licensed to PSF under a contributor agreement.
 package uk.co.farowl.vsj4.runtime;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -73,12 +69,14 @@ class BootstrapTest {
 
     /** Threads in total. &gt;&gt; {@code setUpClass()} cases. */
     static final int NTHREADS = 100;
+
     /**
      * Check this many threads actually concurrent. Ideally
-     * &gt;{@code setUpClass()} cases but expectation depends on CPU.
+     * &gt;{@code setUpClass().NCASES} but expectation depends on CPUs.
      */
-    static int MIN_THREADS =
-            Math.min(Runtime.getRuntime().availableProcessors(), 20);
+    static int MIN_THREADS = Math.min(
+            Runtime.getRuntime().availableProcessors(), NTHREADS) / 2;
+
 
     /** Threads to run. */
     static final List<InitThread> threads = new ArrayList<>();
@@ -145,7 +143,9 @@ class BootstrapTest {
         for (Thread t : threads) { ensureStopped(t); }
 
         // Dump the thread times by start time.
-        if (truthy(DUMP_PROPERTY)) { dumpThreads(); }
+        // TODO Make dump conditional again (once test reliable on CI)
+        // if (truthy(DUMP_PROPERTY)) { dumpThreads(); }
+        dumpThreads();
     }
 
     /** Property is defined and nothing like "false". */
@@ -182,6 +182,7 @@ class BootstrapTest {
     }
 
     /** All threads completed. */
+    @SuppressWarnings("static-method")
     @Test
     @DisplayName("All threads complete")
     void allComplete() {
@@ -193,19 +194,22 @@ class BootstrapTest {
     }
 
     /** Some threads started before the bootstrap started. */
+    @SuppressWarnings("static-method")
     @Test
     @DisplayName("A race takes place")
     void aRaceTookPlace() {
         // Enough relative start times should be negative
         long competitors = threads.stream()
                 .filter(t -> t.startNanoTime <= 0L).count();
-        logger.info("{} threads were racing.", competitors);
-        logger.info("Required at least {} racing.", MIN_THREADS);
-        assertTrue(competitors > MIN_THREADS, () -> String
-                .format("Only %d competitors.", competitors));
+        logger.info(
+                "{} threads were racing. (Min {} on this platform.)",
+                competitors, MIN_THREADS);
+        assertFalse(competitors < MIN_THREADS, () -> String
+                .format("Detect < %d competitors.", MIN_THREADS));
     }
 
     /** Bootstrap completed before the first action completed. */
+    @SuppressWarnings("static-method")
     @Test
     @DisplayName("The bootstrap completes before any action.")
     void bootstrapBeforeAction() {
@@ -221,6 +225,7 @@ class BootstrapTest {
     }
 
     /** All the threads see the same type registry. */
+    @SuppressWarnings("static-method")
     @Test
     @DisplayName("All threads see the same type registry")
     void sameTypeRegistry() {
@@ -231,6 +236,7 @@ class BootstrapTest {
     }
 
     /** All the threads see a correct PyFloat.TYPE. */
+    @SuppressWarnings("static-method")
     @Test
     @DisplayName("All threads see 'float'")
     void sameFloat() {

--- a/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/BootstrapTest.java
+++ b/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/BootstrapTest.java
@@ -288,7 +288,8 @@ class BootstrapTest {
                 action();
             } catch (Throwable e) {
                 logger.atWarn().setMessage("action() threw {}")
-                        .addArgument(e).log();
+                        .addArgument(e.getClass().getSimpleName())
+                        .log();
             }
             firstNanoTime = System.nanoTime();
             otherActions();

--- a/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/StaticTYPETest.java
+++ b/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/StaticTYPETest.java
@@ -162,7 +162,9 @@ class StaticTYPETest {
         }
 
         // Make sure they all stop (so the test does).
-        for (Thread t : threads) { ensureStopped(t); }
+        boolean allStopped = true;
+        for (Thread t : threads) { allStopped &= ensureStopped(t); }
+        assertTrue(allStopped, "A forced stop was needed");
 
         // Dump the thread times by start time.
         if (truthy(DUMP_PROPERTY)) { dumpThreads(); }
@@ -194,11 +196,13 @@ class StaticTYPETest {
     }
 
     @SuppressWarnings("deprecation")
-    private static void ensureStopped(Thread t) {
+    private static boolean ensureStopped(Thread t) {
         if (t.isAlive()) {
-            logger.warn("Forcing stop {}", t.getName());
-            t.stop();
+            logger.warn("Still running {}", t.getName());
+            // t.stop();
+            return false;
         }
+        return true;
     }
 
     /** All threads completed. */

--- a/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/StaticTYPETest.java
+++ b/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/StaticTYPETest.java
@@ -77,7 +77,7 @@ class StaticTYPETest {
     @BeforeAll
     static void setUpClass() {
         // Match the number of cases. (We keep adding to them.)
-        final int NCASES = 13;
+        final int NCASES = 14;
         // Create NTHREADS choosing which action comes first.
         for (int i = 0; i < NTHREADS; i++) {
             int k = i % NCASES;
@@ -139,10 +139,15 @@ class StaticTYPETest {
 
                 // FIXME PyTuple is a deadlock hazard used in MRO
                 // But type.mro() is wrong anyway. Should it be list?
-                // case 11 -> new InitThread(k, PyTuple.class) {
-                // @Override
-                // void action() { type = PyTuple.TYPE; }
-                // };
+                case 11 -> new InitThread(k, PyTuple.class) {
+                    @Override
+                    void action() { type = PyTuple.TYPE; }
+                };
+
+                case 12 -> new InitThread(k, PyList.class) {
+                    @Override
+                    void action() { type = PyList.TYPE; }
+                };
 
                 default -> new InitThread(k, BaseType.class) {
                     @Override
@@ -233,7 +238,9 @@ class StaticTYPETest {
         long competitors = threads.stream()
                 .filter(t -> t.startNanoTime <= 0L).count();
         logger.info("{} threads were racing.", competitors);
-        assertTrue(competitors > 20L, () -> String
+        // Ideally > NCLAUSES but becomes flakey on a small machine.
+        long MIN_THREADS = 10L;
+        assertTrue(competitors > MIN_THREADS, () -> String
                 .format("Only %d competitors.", competitors));
     }
 

--- a/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/StaticTYPETest.java
+++ b/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/StaticTYPETest.java
@@ -60,12 +60,13 @@ class StaticTYPETest {
 
     /** Threads in total. &gt;&gt; {@code setUpClass().NCASES} */
     static final int NTHREADS = 100;
+
     /**
      * Check this many threads actually concurrent. Ideally
-     * &gt;{@code setUpClass().NCASES} but expectation depends on CPU.
+     * &gt;{@code setUpClass().NCASES} but expectation depends on CPUs.
      */
-    static int MIN_THREADS =
-            Math.min(Runtime.getRuntime().availableProcessors(), 20);
+    static int MIN_THREADS = Math.min(
+            Runtime.getRuntime().availableProcessors(), NTHREADS) / 2;
 
     /** Threads to run. */
     static final List<InitThread> threads = new ArrayList<>();
@@ -185,7 +186,9 @@ class StaticTYPETest {
         assertTrue(allStopped, "Threads were still running");
 
         // Dump the thread times by start time.
-        if (truthy(DUMP_PROPERTY)) { dumpThreads(); }
+        // TODO Make dump conditional again (once test reliable on CI)
+        // if (truthy(DUMP_PROPERTY)) { dumpThreads(); }
+        dumpThreads();
     }
 
     /** Property is defined and nothing like "false". */
@@ -235,7 +238,7 @@ class StaticTYPETest {
                         threads.size() - completed));
     }
 
-    /** Some threads started before the bootstrap started. */
+    /** Enough threads started before the first action completed. */
     @SuppressWarnings("static-method")
     @Test
     @DisplayName("A race takes place")
@@ -243,7 +246,9 @@ class StaticTYPETest {
         // Enough relative start times should be negative
         long competitors = threads.stream()
                 .filter(t -> t.startNanoTime <= 0L).count();
-        logger.info("{} threads were racing.", competitors);
+        logger.info(
+                "{} threads were racing. (Min {} on this platform.)",
+                competitors, MIN_THREADS);
         assertFalse(competitors < MIN_THREADS, () -> String
                 .format("Detect < %d competitors.", MIN_THREADS));
     }

--- a/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/StaticTYPETest.java
+++ b/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/StaticTYPETest.java
@@ -313,16 +313,18 @@ class StaticTYPETest {
      * reasonably printable.
      */
     static abstract class InitThread extends Thread {
+        /** The primary class of the type this thread addresses. */
+        final Class<?> klass;
+
         /** Time this thread started. */
         long startNanoTime;
         /** Time this thread completed {@code action()}. */
         long firstNanoTime;
         /** Time this thread completed {@code otherActions()}. */
         long finishNanoTime;
+
         /** The reference {@link TypeSystem#registry} when inspected. */
         TypeRegistry reg;
-        /** The primary class of the type this thread addresses. */
-        Class<?> klass;
         /** The value seen in {@code TYPE}. */
         PyType type;
         /** The value seen in {@link PyLong#TYPE}. */
@@ -333,8 +335,10 @@ class StaticTYPETest {
         PyType getsetType;
 
         /**
-         * Create a {@code Thread} to run. Providing a reference to a
-         * class here does <i>not</i> statically initialise it.
+         * Create a {@code Thread} to run. We specialise this with a
+         * specific definition of {@link #action()}. Providing a
+         * reference to a class here does <i>not</i> statically
+         * initialise it.
          *
          * @param choice of type for this thread
          * @param klass canonical class of TYPE accessed

--- a/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/kernel/TypeFactoryTest.java
+++ b/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/kernel/TypeFactoryTest.java
@@ -16,15 +16,15 @@ import uk.co.farowl.vsj4.runtime.PyType;
  * Test that the Python type system, {@link TypeFactory} and instances
  * of a few associated classes, may be brought into operation in a
  * consistent state. The {@code TypeFactory} is normally a singleton,
- * created during the static initialisation of {@link PyType}, but for
+ * created during the static initialisation of the type system, but for
  * the purpose of testing, we make and discard instances repeatedly.
  * <p>
  * The design keeps the number of <i>materially</i> different
  * initialisation paths to a minimum. In practice, we funnel all actions
  * that cause initialisation into essentially the same bootstrap
- * process, in the static initialisation of {@link PyType}. It is too
- * difficult to reason about otherwise. In this test we subvert that to
- * test copies of the parts separately.
+ * process, in the static initialisation of {@link TypeSystem}. It is
+ * too difficult to reason about otherwise. In this test we subvert that
+ * to test copies of the parts separately.
  * <p>
  * When testing, we arrange to run each test involving initialisation in
  * a new JVM. (See the {@code kernelTest} target in the build.)

--- a/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/kernel/TypeFactoryTest.java
+++ b/rt4core/src/kernelTest/java/uk/co/farowl/vsj4/runtime/kernel/TypeFactoryTest.java
@@ -38,7 +38,7 @@ class TypeFactoryTest {
     @SuppressWarnings({"deprecation", "static-method"})
     void object_exists() {
         TypeFactory factory = new TypeFactory();
-        PyType object = factory.typeForType().getBase();
+        PyType object = factory.createTypeForType().getBase();
         assertNotNull(object);
         assertInstanceOf(SimpleType.class, object);
         assertEquals("object", object.getName());
@@ -50,7 +50,7 @@ class TypeFactoryTest {
     @SuppressWarnings({"deprecation", "static-method"})
     void type_exists() {
         TypeFactory factory = new TypeFactory();
-        PyType type = factory.typeForType();
+        PyType type = factory.createTypeForType();
         assertNotNull(type);
         assertInstanceOf(SimpleType.class, type);
         assertEquals("type", type.getName());
@@ -62,7 +62,7 @@ class TypeFactoryTest {
     @SuppressWarnings({"deprecation", "unused", "static-method"})
     void type_type_unpublished() {
         TypeFactory factory = new TypeFactory();
-        PyType ignored = factory.typeForType();
+        PyType ignored = factory.createTypeForType();
         TypeRegistry registry = factory.getRegistry();
         Representation rep = registry.lookup(PyType.class);
         assertNull(rep);
@@ -74,7 +74,7 @@ class TypeFactoryTest {
     @SuppressWarnings({"deprecation", "unused", "static-method"})
     void object_type_unpublished() {
         TypeFactory factory = new TypeFactory();
-        PyType ignored = factory.typeForType();
+        PyType ignored = factory.createTypeForType();
         TypeRegistry registry = factory.getRegistry();
         Representation rep = registry.lookup(Object.class);
         assertNull(rep);

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/Abstract.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/Abstract.java
@@ -604,6 +604,7 @@ public class Abstract {
 
         } else if (clsType.isSubTypeOf(PyTuple.TYPE)) {
             // cls is a tuple of (should be) types
+            // TODO Recursive call monitoring: needed in Jython?
             // try (RecursionState state = ThreadState
             // .enterRecursiveCall("in __instancecheck__")) {
             // Result is true if true for any type in cls
@@ -619,6 +620,7 @@ public class Abstract {
             Object checker = lookupSpecial(cls, "__instancecheck__");
             if (checker != null) {
                 // cls has an __instancecheck__ to consult.
+                // TODO Recursive call monitoring: needed in Jython?
                 // try (RecursionState state = ThreadState
                 // .enterRecursiveCall("in __instancecheck__")) {
                 return isTrue(Callables.call(checker, inst));
@@ -695,6 +697,7 @@ public class Abstract {
             return recursiveIsSubclass(derived, cls);
 
         } else if (clsType.isSubTypeOf(PyTuple.TYPE)) {
+            // TODO Recursive call monitoring: needed in Jython?
             // try (RecursionState state = ThreadState
             // .enterRecursiveCall(" in __subclasscheck__")) {
             for (Object item : (PyTuple)cls) {
@@ -709,6 +712,7 @@ public class Abstract {
             Object checker = lookupSpecial(cls, "__subclasscheck__");
 
             if (checker != null) {
+                // TODO Recursive call monitoring: needed in Jython?
                 // try (RecursionState state = ThreadState
                 // .enterRecursiveCall(" in __subclasscheck__")) {
                 return isTrue(Callables.call(checker, derived));
@@ -1146,49 +1150,6 @@ public class Abstract {
     /** Throw generic something went wrong internally (last resort). */
     static void badInternalCall() {
         throw new InterpreterError("bad internal call");
-    }
-
-    /**
-     * Convert any {@code Throwable} except an {@code Error} to a
-     * {@code RuntimeException}, as by
-     * {@link #asUnchecked(Throwable, String, Object...) asUnchecked(t,
-     * ...)} with a default message.
-     *
-     * @param t to propagate or encapsulate
-     * @return run-time exception to throw
-     */
-    static RuntimeException asUnchecked(Throwable t) {
-        return asUnchecked(t, "non-Python Exception");
-    }
-
-    /**
-     * Convert any {@code Throwable} except an {@code Error} to a
-     * {@code RuntimeException}, so that (if not already) it becomes an
-     * unchecked exception. An {@code Error} is re-thrown directly. We
-     * use this in circumstances where a method cannot be declared to
-     * throw the exceptions that methods within it are declared to
-     * throw, and no specific handling is available locally.
-     * <p>
-     * In particular, we use it where a call is made to
-     * {@code MethodHandle.invokeExact}. That is declared to throw
-     * {@code Throwable}, but we know that the {@code Throwable} will
-     * either be a {@code PyException} or will signify an interpreter
-     * error that the local code cannot be expected to handle.
-     *
-     * @param t to propagate or encapsulate
-     * @param during format string for detail message, typically like
-     *     "during map.get(%.50s)" where {@code args} contains the key.
-     * @param args to insert into format string.
-     * @return run-time exception to throw
-     */
-    static RuntimeException asUnchecked(Throwable t, String during,
-            Object... args) {
-        if (t instanceof RuntimeException)
-            return (RuntimeException)t;
-        else if (t instanceof Error)
-            throw (Error)t;
-        else
-            return new InterpreterError(t, during, args);
     }
 
     /**

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/ArgumentError.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/ArgumentError.java
@@ -13,6 +13,8 @@ package uk.co.farowl.vsj4.runtime;
  * {@code ArgumentError} should be caught as soon as the necessary
  * context is available and converted to a Python exception.
  */
+// TODO Extend ArgumentError to type errors when invokeExact fails
+// Necessary context is the arguments, handle and ArgParser.
 public class ArgumentError extends Exception {
     private static final long serialVersionUID = 1L;
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/Callables.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/Callables.java
@@ -5,7 +5,8 @@ package uk.co.farowl.vsj4.runtime;
 import java.util.Arrays;
 import java.util.Map;
 
-import uk.co.farowl.vsj4.runtime.internal._PyUtil;
+import uk.co.farowl.vsj4.runtime.kernel.Representation;
+import uk.co.farowl.vsj4.support.internal.EmptyException;
 import uk.co.farowl.vsj4.support.internal.Util;
 
 /** Support for the {@code __call__} protocol of Python objects. */
@@ -19,12 +20,13 @@ public class Callables extends Abstract {
     private static final String[] NO_KEYWORDS = Util.EMPTY_STRING_ARRAY;
 
     /**
-     * Call an object with the standard {@code __call__} protocol, that
-     * is, with an array of all the arguments, those given by position,
-     * then those given by keyword, and an array of the keywords in the
-     * same order. Therefore {@code np = args.length - names.length}
-     * arguments are given by position, and the keyword arguments are
-     * {@code args[np:]} named by {@code names[:]}.
+     * Call an object with with an array of all the arguments, those
+     * given by position, then those given by keyword, and an array of
+     * the keywords in the same order. Therefore
+     * {@code np = args.length - names.length} arguments are given by
+     * position, and the keyword arguments are {@code args[np:]} named
+     * by {@code names[:]}. It will use the {@link FastCall} interface
+     * if the {@code callable} supports it.
      *
      * @param callable target
      * @param args all the arguments (position then keyword)
@@ -38,21 +40,38 @@ public class Callables extends Abstract {
     public static Object call(Object callable, Object[] args,
             String[] names) throws PyBaseException, Throwable {
 
-        // Speed up the common idiom:
-        // if (names == null || names.length == 0) ...
-        if (names != null && names.length == 0) { names = null; }
-
         if (callable instanceof FastCall fast) {
             // Fast path recognising optimised callable
             try {
-                return fast.call(args, names);
+                if (names == null || names.length == 0) {
+                    // No arguments by keyword
+                    switch (args.length) {
+                        case 0:
+                            return fast.call();
+                        case 1:
+                            return fast.call(args[0]);
+                        case 2:
+                            return fast.call(args[0], args[1]);
+                        case 3:
+                            return fast.call(args[0], args[1], args[2]);
+                        case 4:
+                            return fast.call(args[0], args[1], args[2],
+                                    args[3]);
+                        default:
+                            return fast.call(args);
+                    }
+                } else {
+                    // Some arguments by keyword
+                    return fast.call(args, names);
+                }
             } catch (ArgumentError ae) {
-                // Demand a proper TypeError.
+                // TypeError needs full argument list to make sense.
                 throw fast.typeError(ae, args, names);
             }
+
         } else {
-            // Go via callable.__call__
-            return _PyUtil.standardCall(callable, args, names);
+            // Go via callable.__call__ special method
+            return standardCall(callable, args, names);
         }
     }
 
@@ -205,11 +224,6 @@ public class Callables extends Abstract {
 
         return callTupleDict(callable, ar, kw);
     }
-
-    private static final String OBJECT_NOT_VECTORCALLABLE =
-            "'%.200s' object does not support vectorcall";
-    private static final String ATTR_NOT_CALLABLE =
-            "attribute of type '%.200s' is not callable";
 
     /**
      * Convert classic call arguments to an array and names of keywords
@@ -371,7 +385,8 @@ public class Callables extends Abstract {
     }
 
     /**
-     * Call an object with no arguments.
+     * Call an object with no arguments. Use the {@link FastCall}
+     * interface if the {@code callable} supports it.
      *
      * @param callable target
      * @return the return from the call to the object
@@ -380,7 +395,7 @@ public class Callables extends Abstract {
      */
     // Compare CPython _PyObject_CallNoArg in abstract.h
     // and _PyObject_Vectorcall in abstract.h
-    static Object call(Object callable) throws Throwable {
+    public static Object call(Object callable) throws Throwable {
         if (callable instanceof FastCall fast) {
             // Fast path recognising optimised callable
             try {
@@ -391,11 +406,12 @@ public class Callables extends Abstract {
             }
         }
         // Fast call is not supported by the type. Make standard call.
-        return call(callable, NO_ARGS, NO_KEYWORDS);
+        return standardCall(callable, NO_ARGS, NO_KEYWORDS);
     }
 
     /**
-     * Call an object with one positional argument.
+     * Call an object with one positional argument. Use the
+     * {@link FastCall} interface if the {@code callable} supports it.
      *
      * @param callable target
      * @param a0 single argument (may be {@code self})
@@ -416,11 +432,12 @@ public class Callables extends Abstract {
             }
         }
         // Fast call is not supported by the type. Make standard call.
-        return call(callable, new Object[] {a0}, NO_KEYWORDS);
+        return standardCall(callable, new Object[] {a0}, NO_KEYWORDS);
     }
 
     /**
-     * Call an object with two positional arguments.
+     * Call an object with two positional arguments. Use the
+     * {@link FastCall} interface if the {@code callable} supports it.
      *
      * @param callable target
      * @param a0 zeroth argument (may be {@code self})
@@ -442,11 +459,13 @@ public class Callables extends Abstract {
             }
         }
         // Fast call is not supported by the type. Make standard call.
-        return call(callable, new Object[] {a0, a1}, NO_KEYWORDS);
+        return standardCall(callable, new Object[] {a0, a1},
+                NO_KEYWORDS);
     }
 
     /**
-     * Call an object with three positional arguments.
+     * Call an object with three positional arguments. Use the
+     * {@link FastCall} interface if the {@code callable} supports it.
      *
      * @param callable target
      * @param a0 zeroth argument (may be {@code self})
@@ -469,11 +488,13 @@ public class Callables extends Abstract {
             }
         }
         // Fast call is not supported by the type. Make standard call.
-        return call(callable, new Object[] {a0, a1, a2}, NO_KEYWORDS);
+        return standardCall(callable, new Object[] {a0, a1, a2},
+                NO_KEYWORDS);
     }
 
     /**
-     * Call an object with four positional arguments.
+     * Call an object with four positional arguments. Use the
+     * {@link FastCall} interface if the {@code callable} supports it.
      *
      * @param callable target
      * @param a0 zeroth argument (may be {@code self})
@@ -497,13 +518,14 @@ public class Callables extends Abstract {
             }
         }
         // Fast call is not supported by the type. Make standard call.
-        return call(callable, new Object[] {a0, a1, a2, a3},
+        return standardCall(callable, new Object[] {a0, a1, a2, a3},
                 NO_KEYWORDS);
     }
 
     /**
      * Call an object with positional arguments supplied from Java as
-     * {@code Object}s. This is equivalent to
+     * {@code Object}s. Use the {@link FastCall} interface if the
+     * resolved object supports it. This is equivalent to
      * {@code call(callable, args, NO_KEYWORDS)}. The name differs from
      * {@link #call(Object, Object[], String[]) call} only to separate
      * the call signatures.
@@ -522,7 +544,8 @@ public class Callables extends Abstract {
 
     /**
      * Resolve a name within an object and then call it with the given
-     * positional arguments supplied from Java.
+     * positional arguments supplied from Java. Use the {@link FastCall}
+     * interface if the resolved object supports it.
      *
      * @param obj target of the method invocation
      * @param name identifying the method
@@ -537,6 +560,34 @@ public class Callables extends Abstract {
         Object callable = getAttr(obj, name);
         return call(callable, args);
     }
+
+    /**
+     * Call an object with the standard protocol, via the
+     * {@code __call__} special method. It will not use the
+     * {@link FastCall} interface.
+     *
+     * @param callable target
+     * @param args all the arguments (position then keyword)
+     * @param names of the keyword arguments or {@code null}
+     * @return the return from the call to the object
+     * @throws PyBaseException (TypeError) if target is not callable
+     * @throws Throwable for errors raised in the function
+     */
+    public static Object standardCall(Object callable, Object[] args,
+            String[] names) throws PyBaseException, Throwable {
+        Representation rep = representation(callable);
+        try {
+            // Speed up the common idiom:
+            // if (names == null || names.length == 0) ...
+            if (names != null && names.length == 0) { names = null; }
+            return rep.op_call().invokeExact(callable, args, names);
+        } catch (EmptyException e) {
+            throw Abstract.typeError(OBJECT_NOT_CALLABLE, callable);
+        }
+    }
+
+    private static final String OBJECT_NOT_CALLABLE =
+            "'%.200s' object is not callable";
 
     /**
      * Convert a {@code tuple} of names to an array of Java

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/Descriptor.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/Descriptor.java
@@ -46,7 +46,7 @@ abstract class Descriptor implements WithClass {
      */
     // In CPython, called d_qualname.
     // TODO: Where is this used? Is it better computed?
-    private String qualname = null;
+    private String qualname;
 
     /**
      * Create the common part of {@code Descriptor} sub-classes.

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/FastCall.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/FastCall.java
@@ -335,50 +335,49 @@ public interface FastCall {
         return typeError(ae, s, p, p + n, null);
     }
 
-// XXX Depends on classes not yet ported to VSJ4. Revisit.
-// /**
-// * A class that wraps any {@code Object} so that it presents the
-// * {@link FastCall} interface. Any type of {@code call} will
-// * eventually try to invoke the {@code __call__} special method on
-// * the object passed to the constructor.
-// * <p>
-// * This will not make a slow {@code __call__} fast, but it
-// * <i>will</i> make a {@code FastCall} slow.
-// */
-// static class Slow implements FastCall {
-//
-// private final Object callable;
-//
-// Slow(Object callable) { this.callable = callable; }
-//
-// @Override
-// public Object call(Object[] args, String[] names)
-// throws ArgumentError, Throwable {
-// // Call it slowly.
-// return Callables.call(callable, args, names);
-// }
-//
-// @Override
-// public PyBaseException typeError(ArgumentError ae,
-// Object[] args, String[] names) {
-// /*
-// * The underlying callable has thrown an ArgumentError,
-// * which is quite unlikely unless it also implements
-// * FastCall.
-// */
-// if (callable instanceof FastCall) {
-// return ((FastCall)callable).typeError(ae, args, names);
-// } else {
-// // We'll do our best to make a message somehow.
-// String name;
-// try {
-// name = PyUnicode.asString(Abstract.repr(callable));
-// } catch (Throwable e) {
-// name = "callable";
-// }
-// // Probably meaningful interpretation of the error
-// return PyJavaFunction.typeError(name, ae, args, names);
-// }
-// }
-// }
+    /**
+     * A class that wraps any {@code Object} so that it presents the
+     * {@link FastCall} interface. Any type of {@code call} will
+     * eventually try to invoke the {@code __call__} special method on
+     * the object passed to the constructor.
+     * <p>
+     * This will not make a slow {@code __call__} fast, but it
+     * <i>will</i> make a {@code FastCall} slow.
+     */
+    static class Slow implements FastCall {
+
+        private final Object callable;
+
+        Slow(Object callable) { this.callable = callable; }
+
+        @Override
+        public Object call(Object[] args, String[] names)
+                throws ArgumentError, Throwable {
+            // Call it slowly.
+            return Callables.standardCall(callable, args, names);
+        }
+
+        @Override
+        public PyBaseException typeError(ArgumentError ae,
+                Object[] args, String[] names) {
+            /*
+             * The underlying callable has thrown an ArgumentError,
+             * which is quite unlikely unless it also implements
+             * FastCall.
+             */
+            if (callable instanceof FastCall) {
+                return ((FastCall)callable).typeError(ae, args, names);
+            } else {
+                // We'll do our best to make a message somehow.
+                String name;
+                try {
+                    name = PyUnicode.asString(Abstract.repr(callable));
+                } catch (Throwable e) {
+                    name = "callable";
+                }
+                // Probably meaningful interpretation of the error
+                return PyJavaFunction.typeError(name, ae, args, names);
+            }
+        }
+    }
 }

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyBaseException.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyBaseException.java
@@ -115,20 +115,26 @@ public class PyBaseException extends RuntimeException
      */
     private boolean suppressContext;
 
-    // XXX current format and args could be applied to message.
-
     /**
      * Constructor specifying Python type and the argument tuple as the
-     * associated value. We do this for maximum similarity with CPython,
-     * where {@code __new__} does no more than allocate an object and
-     * all attribute values are decoded by {@code __init__}.
+     * associated value of the exception. We do this for maximum
+     * similarity with CPython, where {@code __new__} does no more than
+     * allocate an object and all attribute values are decoded by
+     * {@code __init__}.
+     * <p>
+     * The type of an exception may be changed, within limits. The
+     * initial {@code type} is checked to see that if shares this class
+     * as its representation. E.g. {@code UnboundLocalError} and
+     * {@code NameError} share the representation created by
+     * {@link PyNameError#TYPE}. Once the object is created,
+     * {@link #setType(Object)} makes effectively the same check.
      *
      * @param type Python type of the exception
      * @param args positional arguments
      */
     public PyBaseException(PyType type, PyTuple args) {
-        // Ensure Python type is valid for Java class.
-        this.type = checkClassAssignment(type);
+        // Ensure Python type is compatible with type family.
+        this.type = PyUtil.checkReplaceable(this.getClass(), type);
         this.args = args;
     }
 
@@ -147,7 +153,7 @@ public class PyBaseException extends RuntimeException
 
     @Override
     public void setType(Object replacementType) {
-        type = checkClassAssignment(replacementType);
+        type = PyUtil.checkReplaceable(getType(), replacementType);
     }
 
     // Exception API -------------------------------------------------

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyBool.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyBool.java
@@ -38,7 +38,7 @@ public final class PyBool {
     }
 
     /** The Python type {@code bool}. */
-    public static final PyType TYPE = TypeSystem.typeOf(Boolean.TRUE);
+    public static final PyType TYPE = TypeSystem.TYPE_bool;
 
     private PyBool() {}  // enforces the doubleton :)
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyBool.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyBool.java
@@ -2,6 +2,9 @@
 // Licensed to PSF under a contributor agreement.
 package uk.co.farowl.vsj4.runtime;
 
+import java.lang.invoke.MethodHandles;
+import java.math.BigInteger;
+
 import uk.co.farowl.vsj4.runtime.Exposed.Default;
 import uk.co.farowl.vsj4.runtime.Exposed.DocString;
 import uk.co.farowl.vsj4.runtime.Exposed.PythonNewMethod;
@@ -15,8 +18,27 @@ import uk.co.farowl.vsj4.runtime.Exposed.PythonNewMethod;
  */
 public final class PyBool {
 
+    /** Only referenced during bootstrap by {@link TypeSystem}. */
+    static class Spec {
+        /**
+         * The {@code get()} of {@code PyBool.Spec} has a special form
+         * that allows us to communicate its Python base {@code int}
+         * before that object can be reliably referenced as
+         * {@link PyLong#TYPE}.
+         *
+         * @param base type object ({@code int}) to cite as a base
+         * @return the type specification.
+         */
+        static TypeSpec get(PyType base) {
+            return new TypeSystem.BootstrapSpec("bool",
+                    MethodHandles.lookup(), Boolean.class)
+                            .methodImpls(PyBool.class) //
+                            .base(base);
+        }
+    }
+
     /** The Python type {@code bool}. */
-    public static final PyType TYPE = PyType.of(Boolean.TRUE);
+    public static final PyType TYPE = TypeSystem.typeOf(Boolean.TRUE);
 
     private PyBool() {}  // enforces the doubleton :)
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyErr.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyErr.java
@@ -1,6 +1,8 @@
-// Copyright (c)2024 Jython Developers.
+// Copyright (c)2025 Jython Developers.
 // Licensed to PSF under a contributor agreement.
 package uk.co.farowl.vsj4.runtime;
+
+import uk.co.farowl.vsj4.support.internal.Util;
 
 /**
  * Convenience methods for creating and manipulating Python exceptions.
@@ -38,7 +40,7 @@ public class PyErr {
         try {
             return (PyBaseException)Callables.call(excType, msg);
         } catch (Throwable e) {
-            throw Abstract.asUnchecked(e);
+            throw Util.asUnchecked(e);
         }
     }
 }

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyFloat.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyFloat.java
@@ -8,6 +8,7 @@ import static uk.co.farowl.vsj4.runtime.ClassShorthand.T;
 import static uk.co.farowl.vsj4.runtime.PyFloatMethods.toDouble;
 
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.math.BigInteger;
 
 import uk.co.farowl.vsj4.runtime.PyUtil.NoConversion;
@@ -24,9 +25,24 @@ import uk.co.farowl.vsj4.support.internal.EmptyException;
  * {@code double} or {@code java.lang.Double} when boxed as an object.
  */
 public class PyFloat implements WithClass {
-    /** The type object {@code float}. */
+
+    // TODO Make 'float' adopt Float.class
+    /** Only referenced during bootstrap by {@link TypeSystem}. */
+    static class Spec {
+        /** @return the type specification. */
+        static TypeSpec get() {
+            return new TypeSystem.BootstrapSpec("float",
+                    MethodHandles.lookup(), PyFloat.class)
+                            .add(Feature.BASETYPE)
+                            .methodImpls(PyFloatMethods.class)
+                            // .binops(PyFloatBinops.class)
+                            .adopt(Double.class);
+        }
+    }
+
+    /** The Python type of {@code float} objects. */
     // Bootstrap type so ask the type system to resolve it.
-    public static final PyType TYPE = PyType.of(0.0);
+    public static final PyType TYPE = TypeSystem.typeOf(0.0);
 
     /** Value of this Python {@code float} as a Java primitive. */
     final double value;

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyGetSetDescr.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyGetSetDescr.java
@@ -41,9 +41,15 @@ public abstract class PyGetSetDescr extends DataDescriptor {
         }
     }
 
-    /** The Python type of {@code getset_descriptor} objects. */
-    public static final PyType TYPE =
-            TypeSystem.typeForClass(PyGetSetDescr.class);
+    /**
+     * Return the Python type of {@code getset_descriptor} objects,
+     * {@code types.GetSetDescriptorType}.
+     *
+     * @return {@code <class 'getset_descriptor'>}
+     */
+    public static final PyType TYPE() {
+        return TypeSystem.TYPE_getset_descriptor;
+    }
 
     /** The method handle type (O)O. */
     // CPython: PyObject *(*getter)(PyObject *, void *)
@@ -114,7 +120,7 @@ public abstract class PyGetSetDescr extends DataDescriptor {
     }
 
     @Override
-    public PyType getType() { return TYPE; }
+    public PyType getType() { return TYPE(); }
 
     /**
      * Return a {@code MethodHandle} by which the Java implementation of

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyGetSetDescr.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyGetSetDescr.java
@@ -31,11 +31,19 @@ import uk.co.farowl.vsj4.support.internal.EmptyException;
 // and PyGetSetDescrObject also in descrobject.h
 public abstract class PyGetSetDescr extends DataDescriptor {
 
-    static final Lookup LOOKUP = MethodHandles.lookup();
-    static final PyType TYPE =
-            PyType.fromSpec(new TypeSpec("getset_descriptor", LOOKUP)
-                    .add(Feature.IMMUTABLE, Feature.METHOD_DESCR)
-                    .remove(Feature.BASETYPE));
+    /** Only referenced during bootstrap by {@link TypeSystem}. */
+    static class Spec {
+        /** @return the type specification. */
+        static TypeSpec get() {
+            return new TypeSystem.BootstrapSpec("getset_descriptor",
+                    MethodHandles.lookup(), PyGetSetDescr.class)
+                            .remove(Feature.INSTANTIABLE);
+        }
+    }
+
+    /** The Python type of {@code getset_descriptor} objects. */
+    public static final PyType TYPE =
+            TypeSystem.typeForClass(PyGetSetDescr.class);
 
     /** The method handle type (O)O. */
     // CPython: PyObject *(*getter)(PyObject *, void *)
@@ -61,6 +69,7 @@ public abstract class PyGetSetDescr extends DataDescriptor {
          * fail (in theory).
          */
         try {
+            Lookup LOOKUP = MethodHandles.lookup();
             EMPTY_GETTER = LOOKUP.findStatic(PyGetSetDescr.class,
                     "emptyGetter", GETTER);
             EMPTY_SETTER = LOOKUP.findStatic(PyGetSetDescr.class,

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyJavaFunction.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyJavaFunction.java
@@ -40,10 +40,14 @@ public abstract class PyJavaFunction implements WithClass, FastCall {
     }
 
     /**
-     * The Python type of {@code builtin_function_or_method} objects.
+     * Return the Python type of {@code builtin_function_or_method}
+     * objects, {@code types.BuiltinMethodType}.
+     *
+     * @return {@code <class 'builtin_function_or_method'>}
      */
-    public static PyType TYPE =
-            TypeSystem.typeForClass(PyJavaFunction.class);
+    public static final PyType TYPE() {
+        return TypeSystem.TYPE_builtin_function_or_method;
+    }
 
     /** Name of the containing module (or {@code null}). */
     final String module;
@@ -107,7 +111,7 @@ public abstract class PyJavaFunction implements WithClass, FastCall {
     }
 
     @Override
-    public PyType getType() { return TYPE; }
+    public PyType getType() { return TYPE(); }
 
     /**
      * Construct a {@code PyJavaFunction} from an {@link ArgParser} and

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyJavaFunction.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyJavaFunction.java
@@ -217,7 +217,10 @@ public abstract class PyJavaFunction implements WithClass, FastCall {
      * Construct a {@code PyJavaFunction} from an {@link ArgParser} and
      * {@code MethodHandle} for a {@code __new__} method. Although
      * {@code __new__} is a static method the {@code PyJavaFunction} we
-     * produce is bound to the defining {@code PyType self}.
+     * produce is bound (by setting {@link #self}) to the defining
+     * {@code PyType self}. The {@link #handle} derived from
+     * {@code method} is <i>not</i> bound to {@code self}, but
+     * <i>does</i> add a filter to check the type of the first argument.
      *
      * @param ap argument parser (provides argument names etc.)
      * @param method raw handle to the method defined
@@ -662,9 +665,8 @@ public abstract class PyJavaFunction implements WithClass, FastCall {
         }
 
         @Override
-        public Object call(Object self, Object a0, Object a1)
-                throws Throwable {
-            return handle.invokeExact(self, a0, a1);
+        public Object call(Object a0, Object a1) throws Throwable {
+            return handle.invokeExact(a0, a1);
         }
     }
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyJavaFunction.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyJavaFunction.java
@@ -28,13 +28,22 @@ import uk.co.farowl.vsj4.support.ScopeKind;
  */
 public abstract class PyJavaFunction implements WithClass, FastCall {
 
-    /** The type of Python object this class implements. */
-    static final PyType TYPE = PyType.fromSpec( //
-            new TypeSpec("builtin_function_or_method",
-                    MethodHandles.lookup()));
+    /** Only referenced during bootstrap by {@link TypeSystem}. */
+    static class Spec {
+        /** @return the type specification. */
+        static TypeSpec get() {
+            return new TypeSystem.BootstrapSpec(
+                    "builtin_function_or_method",
+                    MethodHandles.lookup(), PyJavaFunction.class)
+                            .remove(Feature.INSTANTIABLE);
+        }
+    }
 
-    @Override
-    public PyType getType() { return TYPE; }
+    /**
+     * The Python type of {@code builtin_function_or_method} objects.
+     */
+    public static PyType TYPE =
+            TypeSystem.typeForClass(PyJavaFunction.class);
 
     /** Name of the containing module (or {@code null}). */
     final String module;
@@ -96,6 +105,9 @@ public abstract class PyJavaFunction implements WithClass, FastCall {
         this.self = self;
         this.module = module;
     }
+
+    @Override
+    public PyType getType() { return TYPE; }
 
     /**
      * Construct a {@code PyJavaFunction} from an {@link ArgParser} and

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyList.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyList.java
@@ -141,11 +141,18 @@ public class PyList implements List<Object>, WithClass {
      * @param start of slice
      * @param count of elements to take
      */
-    PyList(Object[] a, int start, int count) {
+    public PyList(Object[] a, int start, int count) {
         this(TYPE, count);
         int stop = start + count;
         for (int i = start; i < stop; i++) { add(a[i]); }
     }
+
+    /**
+     * Construct a {@code list} with initial contents from an array.
+     *
+     * @param a the array
+     */
+    public PyList(Object[] a) { this(a, 0, a.length); }
 
     /**
      * Return a Python {@code list} object, specifying initial contents.

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyLong.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyLong.java
@@ -7,6 +7,7 @@ import static java.math.BigInteger.ZERO;
 import static uk.co.farowl.vsj4.runtime.ClassShorthand.T;
 
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.math.BigInteger;
 
 import uk.co.farowl.vsj4.runtime.Exposed.Default;
@@ -25,9 +26,23 @@ import uk.co.farowl.vsj4.runtime.kernel.Representation;
 // TODO: adopt some more types of int
 // TODO: implement PyDict.Key
 public class PyLong implements /* PyDict.Key, */ WithClass {
-    /** The type {@code int}. */
-    // Bootstrap type so ask the type system to resolve it.
-    public static final PyType TYPE = PyType.of(42);
+
+    /** Only referenced during bootstrap by {@link TypeSystem}. */
+    static class Spec {
+        /** @return the type specification. */
+        static TypeSpec get() {
+            return new TypeSystem.BootstrapSpec("int",
+                    MethodHandles.lookup(), PyLong.class)
+                            .add(Feature.BASETYPE)
+                            .methodImpls(PyLongMethods.class)
+                            // .binops(PyLongBinops.class)
+                            .adopt(BigInteger.class, Integer.class)
+                            .accept(Boolean.class);
+        }
+    }
+
+    /** The Python type of {@code int} objects. */
+    public static final PyType TYPE = TypeSystem.typeOf(42);
 
     /** The minimum Java {@code int} as a {@code BigInteger}. */
     static final BigInteger MIN_INT =

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyLong.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyLong.java
@@ -42,7 +42,7 @@ public class PyLong implements /* PyDict.Key, */ WithClass {
     }
 
     /** The Python type of {@code int} objects. */
-    public static final PyType TYPE = TypeSystem.typeOf(42);
+    public static final PyType TYPE = TypeSystem.TYPE_int;
 
     /** The minimum Java {@code int} as a {@code BigInteger}. */
     static final BigInteger MIN_INT =

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyMemberDescr.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyMemberDescr.java
@@ -19,11 +19,19 @@ import uk.co.farowl.vsj4.support.InterpreterError;
  */
 public abstract class PyMemberDescr extends DataDescriptor {
 
-    /** The type of Python object this class implements. */
-    static final PyType TYPE = PyType.fromSpec( //
-            new TypeSpec("member_descriptor", MethodHandles.lookup())
-                    .add(Feature.IMMUTABLE, Feature.METHOD_DESCR)
-                    .remove(Feature.BASETYPE));
+    /** Only referenced during bootstrap by {@link TypeSystem}. */
+    static class Spec {
+        /** @return the type specification. */
+        static TypeSpec get() {
+            return new TypeSystem.BootstrapSpec("member_descriptor",
+                    MethodHandles.lookup(), PyMemberDescr.class)
+                            .remove(Feature.INSTANTIABLE);
+        }
+    }
+
+    /** The Python type of {@code member_descriptor} objects. */
+    public static final PyType TYPE =
+            TypeSystem.typeForClass(PyMemberDescr.class);
 
     /** Acceptable values in the {@link #flags}. */
     enum Flag {

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyMemberDescr.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyMemberDescr.java
@@ -29,9 +29,15 @@ public abstract class PyMemberDescr extends DataDescriptor {
         }
     }
 
-    /** The Python type of {@code member_descriptor} objects. */
-    public static final PyType TYPE =
-            TypeSystem.typeForClass(PyMemberDescr.class);
+    /**
+     * Return the Python type of {@code member_descriptor} objects,
+     * {@code types.MemberDescriptorType}.
+     *
+     * @return {@code <class 'member_descriptor'>}
+     */
+    public static final PyType TYPE() {
+        return TypeSystem.TYPE_member_descriptor;
+    }
 
     /** Acceptable values in the {@link #flags}. */
     enum Flag {
@@ -76,7 +82,7 @@ public abstract class PyMemberDescr extends DataDescriptor {
     }
 
     @Override
-    public PyType getType() { return TYPE; }
+    public PyType getType() { return TYPE(); }
 
     private static VarHandle varHandle(Field f, Lookup lookup) {
         try {

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyMethodDescr.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyMethodDescr.java
@@ -33,11 +33,20 @@ import uk.co.farowl.vsj4.support.internal.Util;
 // and functions method_* in descrobject.c.
 public abstract class PyMethodDescr extends MethodDescriptor {
 
-    /** The type object of a {@code method_descriptor}. */
-    public static final PyType TYPE = PyType.fromSpec( //
-            new TypeSpec("method_descriptor", MethodHandles.lookup())
-                    .add(Feature.IMMUTABLE, Feature.METHOD_DESCR)
-                    .remove(Feature.BASETYPE));
+    /** Only referenced during bootstrap by {@link TypeSystem}. */
+    static class Spec {
+        /** @return the type specification. */
+        static TypeSpec get() {
+            return new TypeSystem.BootstrapSpec("method_descriptor",
+                    MethodHandles.lookup(), PyMethodDescr.class)
+                            .add(Feature.METHOD_DESCR)
+                            .remove(Feature.INSTANTIABLE);
+        }
+    }
+
+    /** The Python type of {@code method_descriptor} objects. */
+    public static PyType TYPE =
+            TypeSystem.typeForClass(PyMethodDescr.class);
 
     /*
      * We depart from CPython in reifying information from the Java

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyMethodDescr.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyMethodDescr.java
@@ -44,9 +44,15 @@ public abstract class PyMethodDescr extends MethodDescriptor {
         }
     }
 
-    /** The Python type of {@code method_descriptor} objects. */
-    public static PyType TYPE =
-            TypeSystem.typeForClass(PyMethodDescr.class);
+    /**
+     * Return the Python type of {@code method_descriptor} objects,
+     * {@code types.MethodDescriptorType}.
+     *
+     * @return {@code <class 'method_descriptor'>}
+     */
+    public static final PyType TYPE() {
+        return TypeSystem.TYPE_method_descriptor;
+    }
 
     /*
      * We depart from CPython in reifying information from the Java
@@ -95,7 +101,7 @@ public abstract class PyMethodDescr extends MethodDescriptor {
     }
 
     @Override
-    public PyType getType() { return TYPE; }
+    public PyType getType() { return TYPE(); }
 
     /**
      * Construct a Python {@code method} descriptor from an

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyMethodWrapper.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyMethodWrapper.java
@@ -29,17 +29,23 @@ public class PyMethodWrapper implements WithClass, FastCall {
         static TypeSpec get() {
             return new TypeSystem.BootstrapSpec("method-wrapper",
                     MethodHandles.lookup(), PyMethodWrapper.class)
-                    .remove(Feature.INSTANTIABLE);
+                            .remove(Feature.INSTANTIABLE);
         }
     }
 
-    /** The Python type of {@code method-wrapper} objects. */
-    public static PyType TYPE =
-            TypeSystem.typeForClass(PyMethodWrapper.class);
+    /**
+     * Return the Python type of {@code method-wrapper} objects,
+     * {@code types.MethodWrapperType}.
+     *
+     * @return {@code <class 'method-wrapper'>}
+     */
+    public static final PyType TYPE() {
+        return TypeSystem.TYPE_method_wrapper;
+    }
 
     // No subclasses so always this type
     @Override
-    public PyType getType() { return TYPE; }
+    public PyType getType() { return TYPE(); }
 
     /** Descriptor for the method being bound. */
     @Exposed.Member

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyMethodWrapper.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyMethodWrapper.java
@@ -23,9 +23,19 @@ import uk.co.farowl.vsj4.runtime.internal._PyUtil;
 // and _PyMethodWrapper_Type in descrobject.c
 public class PyMethodWrapper implements WithClass, FastCall {
 
-    static final PyType TYPE = PyType.fromSpec(
-            new TypeSpec("method-wrapper", MethodHandles.lookup())
-                    .add(Feature.IMMUTABLE));
+    /** Only referenced during bootstrap by {@link TypeSystem}. */
+    static class Spec {
+        /** @return the type specification. */
+        static TypeSpec get() {
+            return new TypeSystem.BootstrapSpec("method-wrapper",
+                    MethodHandles.lookup(), PyMethodWrapper.class)
+                    .remove(Feature.INSTANTIABLE);
+        }
+    }
+
+    /** The Python type of {@code method-wrapper} objects. */
+    public static PyType TYPE =
+            TypeSystem.typeForClass(PyMethodWrapper.class);
 
     // No subclasses so always this type
     @Override

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyNone.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyNone.java
@@ -9,9 +9,17 @@ import uk.co.farowl.vsj4.runtime.internal.Singleton;
 /** The Python {@code None} object. */
 public final class PyNone extends Singleton {
 
+    /** Only referenced during bootstrap by {@link TypeSystem}. */
+    static class Spec {
+        /** @return the type specification. */
+        static TypeSpec get() {
+            return new TypeSystem.BootstrapSpec("NoneType",
+                    MethodHandles.lookup(), PyNone.class);
+        }
+    }
+
     /** The Python type of {@code None}. */
-    public static final PyType TYPE = PyType.fromSpec( //
-            new TypeSpec("NoneType", MethodHandles.lookup()));
+    public static final PyType TYPE = TypeSystem.TYPE_NoneType;
 
     /** The only instance, published as {@link Py#None}. */
     public static final PyNone INSTANCE = new PyNone();

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyObject.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyObject.java
@@ -4,25 +4,20 @@ package uk.co.farowl.vsj4.runtime;
 
 /**
  * Public static methods associated with the Python type {@code object}.
- * The Python {@code object} type is represented by
+ * Instances of the Python {@code object} type are represented by
  * {@code java.lang.Object} and not by instances of this class.
  * <p>
  * The Java implementation class of a type defined in Python <i>will</i>
  * be derived from the canonical implementation class of the "solid
- * base" it inherits in Python. This may well be {@code Object}.
+ * base" it inherits in Python. This may well be
+ * {@code java.lang.Object}.
  */
 // Compare CPython PyBaseObject_Type in typeobject.c
 public final class PyObject {
 
     /** The type object {@code object}. */
-    public static final PyType TYPE =
-            /*
-             * This looks a bit weird, but we need to make sure PyType
-             * gets initialised, and the whole type system behind it,
-             * before the first type object becomes visible.
-             */
-            PyType.of(new Object());
+    public static final PyType TYPE = TypeSystem.TYPE_type.getBase();
 
-    /** One cannot make instances of this class. */
+    /** One cannot make instances of {@code PyObject}. */
     private PyObject() {}
 }

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyStaticMethod.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyStaticMethod.java
@@ -6,6 +6,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.Map;
 
 import uk.co.farowl.vsj4.runtime.Exposed.Getter;
+import uk.co.farowl.vsj4.support.internal.Util;
 
 /**
  * The Python {@code staticmethod} class, that is most often encountered
@@ -115,7 +116,7 @@ public class PyStaticMethod implements WithDict {
                 v = Abstract.lookupAttr(wrapped, name);
                 if (v != null) { Abstract.setAttr(this, name, v); }
             } catch (Throwable e) {
-                throw Abstract.asUnchecked(e, "staticmethod wrapping");
+                throw Util.asUnchecked(e, "staticmethod wrapping");
             }
         }
     }

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyStopIteration.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyStopIteration.java
@@ -4,9 +4,6 @@ package uk.co.farowl.vsj4.runtime;
 
 import java.lang.invoke.MethodHandles;
 
-import uk.co.farowl.vsj4.runtime.Exposed.KeywordOnly;
-import uk.co.farowl.vsj4.runtime.Exposed.PositionalCollector;
-
 /** The Python {@code StopIteration} exception. */
 public class PyStopIteration extends PyBaseException {
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyType.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyType.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import uk.co.farowl.vsj4.runtime.kernel.BaseType;
 import uk.co.farowl.vsj4.runtime.kernel.Representation;
 import uk.co.farowl.vsj4.runtime.kernel.TypeFactory.Clash;
 import uk.co.farowl.vsj4.support.InterpreterError;
@@ -309,12 +310,9 @@ public interface PyType extends WithClass, FastCall {
     // static methods -----------------------------------------------
 
     /**
-     * The Python {@code type} object. The type objects of many built-in
-     * types are available as a static final field {@code TYPE}. For
-     * technical reasons, we have to use a static method to get the
-     * value.
+     * Return the Python type of {@code type} objects.
      *
-     * @return The {@code type} object.
+     * @return {@code type}
      */
     public static PyType TYPE() {
         /*

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyType.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyType.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import uk.co.farowl.vsj4.runtime.kernel.BaseType;
 import uk.co.farowl.vsj4.runtime.kernel.Representation;
 import uk.co.farowl.vsj4.runtime.kernel.TypeFactory.Clash;
 import uk.co.farowl.vsj4.support.InterpreterError;
@@ -316,13 +315,12 @@ public interface PyType extends WithClass, FastCall {
      */
     public static PyType TYPE() {
         /*
-         * The type object "type" is created deep in the type system
-         * with the type factory itself, as might be expected. We
-         * carefully avoid calling this method from that constructor,
-         * but once TypeSystem.factory has been assigned, then the
-         * returned type object is guaranteed to be at least Java ready.
+         * The object "type" is created deep in the type system, during
+         * bootstrapping. The next statement will block any thread other
+         * than the one currently bootstrapping the type system, until
+         * that process is over.
          */
-        return TypeSystem.TYPE;
+        return TypeSystem.TYPE_type;
     }
 
     /**

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyType.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyType.java
@@ -245,7 +245,7 @@ public interface PyType extends WithClass, FastCall {
      * only) representation class, but it is not safe to assume so
      * always. For {@code type} itself, the canonical class is called
      * {@code SimpleType}, and for subclasses defined in Python it may
-     * be the canonical representation of one of an ancestor class.
+     * be the canonical representation of an ancestor Python class.
      *
      * @return the canonical Java representation class of {@code self}
      */

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyType.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyType.java
@@ -5,6 +5,7 @@ package uk.co.farowl.vsj4.runtime;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 
@@ -119,6 +120,14 @@ public interface PyType extends WithClass, FastCall {
     // Compare CPython _PyType_Lookup in typeobject.c
     // and find_name_in_mro in typeobject.c
     Object lookup(String name);
+
+    /**
+     * The features of this type as a set.
+     *
+     * @return features of this type
+     */
+    // Compare CPython PyType_GetFlags
+    EnumSet<TypeFlag> getFeatures();
 
     /**
      * Test for possession of a specified feature.

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyType.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyType.java
@@ -206,9 +206,7 @@ public interface PyType extends WithClass, FastCall {
 
     /**
      * Determine if this type is a Python sub-type of {@code b} (if
-     * {@code b} is on the MRO of this type). For technical reasons we
-     * parameterise with the subclass. (We need it to work with a
-     * private superclass or {@code PyType}.)
+     * {@code b} is on the MRO of this type).
      *
      * @param b to test
      * @return {@code true} if {@code this} is a sub-type of {@code b}

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyUnicode.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyUnicode.java
@@ -60,7 +60,7 @@ public class PyUnicode implements WithClass, PyDict.Key {
     }
 
     /** The Python type of {@code str} objects. */
-    public static final PyType TYPE = TypeSystem.typeOf("");
+    public static final PyType TYPE = TypeSystem.TYPE_str;
 
     /** Value as a Java {@code int} array of code points. */
     private final int[] value;

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyUnicode.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyUnicode.java
@@ -71,8 +71,8 @@ public class PyUnicode implements WithClass, PyDict.Key {
     }
 
     /**
-     * We can quickly determine tha a whether short-cut encodings will
-     * be possible for a given {@code PyUnicode} from this field.
+     * We can quickly determine whether short-cut encodings will be
+     * possible for a given {@code PyUnicode} from this field.
      */
     final private Range range;
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyUnicode.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyUnicode.java
@@ -47,18 +47,25 @@ import uk.co.farowl.vsj4.support.InterpreterError;
  */
 public class PyUnicode implements WithClass, PyDict.Key {
 
-    /** The type {@code str}. */
-    // Bootstrap type so ask the type system to resolve it.
-    public static final PyType TYPE = PyType.of("");
+    /** Only referenced during bootstrap by {@link TypeSystem}. */
+    static class Spec {
+        /** @return the type specification. */
+        static TypeSpec get() {
+            return new TypeSystem.BootstrapSpec("str",
+                    MethodHandles.lookup(), PyUnicode.class)
+                            .add(Feature.BASETYPE)
+                            .methodImpls(PyUnicodeMethods.class)
+                            .adopt(String.class);
+        }
+    }
 
-    /**
-     * The implementation holds a Java {@code int} array of code points.
-     */
+    /** The Python type of {@code str} objects. */
+    public static final PyType TYPE = TypeSystem.typeOf("");
+
+    /** Value as a Java {@code int} array of code points. */
     private final int[] value;
 
-    /**
-     * Enumeration used to express the code point {@link #range}.
-     */
+    /** Enumeration to express the code point {@link #range}. */
     enum Range {
         ASCII, LATIN, BMP, SMP;
     }

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyWrapperDescr.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyWrapperDescr.java
@@ -51,10 +51,20 @@ import uk.co.farowl.vsj4.support.internal.Util;
  */
 public abstract class PyWrapperDescr extends MethodDescriptor {
 
-    static final PyType TYPE = PyType.fromSpec( //
-            new TypeSpec("wrapper_descriptor", MethodHandles.lookup())
-                    .add(Feature.IMMUTABLE, Feature.METHOD_DESCR)
-                    .remove(Feature.BASETYPE));
+    /** Only referenced during bootstrap by {@link TypeSystem}. */
+    static class Spec {
+        /** @return the type specification. */
+        static TypeSpec get() {
+            return new TypeSystem.BootstrapSpec("wrapper_descriptor",
+                    MethodHandles.lookup(), PyWrapperDescr.class)
+                            .add(Feature.METHOD_DESCR)
+                            .remove(Feature.INSTANTIABLE);
+        }
+    }
+
+    /** The Python type of {@code wrapper_descriptor} objects. */
+    public static PyType TYPE =
+            TypeSystem.typeForClass(PyWrapperDescr.class);
 
     /**
      * The {@link SpecialMethod} ({@code enum}) describing the generic

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyWrapperDescr.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/PyWrapperDescr.java
@@ -62,9 +62,15 @@ public abstract class PyWrapperDescr extends MethodDescriptor {
         }
     }
 
-    /** The Python type of {@code wrapper_descriptor} objects. */
-    public static PyType TYPE =
-            TypeSystem.typeForClass(PyWrapperDescr.class);
+    /**
+     * Return the Python type of {@code wrapper_descriptor} objects,
+     * {@code types.WrapperDescriptorType}.
+     *
+     * @return {@code <class 'wrapper_descriptor'>}
+     */
+    public static final PyType TYPE() {
+        return TypeSystem.TYPE_wrapper_descriptor;
+    }
 
     /**
      * The {@link SpecialMethod} ({@code enum}) describing the generic
@@ -87,7 +93,7 @@ public abstract class PyWrapperDescr extends MethodDescriptor {
     }
 
     @Override
-    public PyType getType() { return TYPE; }
+    public PyType getType() { return TYPE(); }
 
     // Exposed attributes ---------------------------------------------
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeExposerImplementation.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeExposerImplementation.java
@@ -151,7 +151,7 @@ class TypeExposerImplementation extends Exposer implements TypeExposer {
             /*
              * Note: method annotations (and special names) are not
              * treated as alternatives, to catch exposure of methods by
-             * multiple routes.
+             * multiple routes, which is an error we detect later.
              */
 
             // Check for instance method
@@ -182,10 +182,17 @@ class TypeExposerImplementation extends Exposer implements TypeExposer {
             Deleter del = m.getAnnotation(Deleter.class);
             if (del != null) { addDeleter(m, del); }
 
-            // If it has a special method name record a definition.
-            String name = m.getName();
-            SpecialMethod sm = SpecialMethod.forMethodName(name);
-            if (sm != null) { addWrapperSpec(m, sm); }
+            /*
+             * If it has a special method name record a definition
+             * without needing specific annotation. (This is excluded
+             * during tests applicable before the type system works,
+             * indicated by type==null.)
+             */
+            if (type != null) {
+                String name = m.getName();
+                SpecialMethod sm = SpecialMethod.forMethodName(name);
+                if (sm != null) { addWrapperSpec(m, sm); }
+            }
         }
     }
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeExposerImplementation.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeExposerImplementation.java
@@ -122,7 +122,7 @@ class TypeExposerImplementation extends Exposer implements TypeExposer {
                         logger.atTrace().addArgument(type.getName())
                                 .addArgument(spec.name)
                                 .addArgument(spec.annoClassName())
-                                .log("-  Add {}.{} ({})");
+                                .log("- Add {}.{} ({})");
                         spec.checkFormation();
                         // Create attribute according to spec type
                         Object attr = spec.asAttribute(type, lookup);
@@ -314,7 +314,7 @@ class TypeExposerImplementation extends Exposer implements TypeExposer {
      */
     void scanJavaFields(Class<?> c) throws InterpreterError {
 
-        logger.atTrace().addArgument(c).log("Finding members in {}");
+        logger.atTrace().addArgument(c).log("Finding fields  in {}");
 
         // Iterate over fields looking for the relevant annotations
         for (Field f : c.getDeclaredFields()) {

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeSpec.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeSpec.java
@@ -86,12 +86,12 @@ public class TypeSpec extends NamedSpec {
      * instances of the specified class as their the {@code self}
      * argument.
      *
-     * See {@link #canonicalBase(Class)}.
+     * See {@link #canonicalClass(Class)}.
      *
      * It may be {@code null} in a type that adopts all its
      * representations.
      */
-    private Class<?> canonicalBase; // FIXME rename canonicalClass +API
+    private Class<?> canonicalClass;
 
     /**
      * The primary class that will represent the instances of the type
@@ -127,7 +127,7 @@ public class TypeSpec extends NamedSpec {
     /**
      * A collection of classes that are allowed to appear as the "other"
      * parameter in binary operations, in addition to
-     * {@link #canonicalBase}, {@link #adopted} and {@link #accepted}.
+     * {@link #canonicalClass}, {@link #adopted} and {@link #accepted}.
      * The main use for this is to allow efficient mixed {@code float}
      * and {@code int} operations.
      */
@@ -268,12 +268,12 @@ public class TypeSpec extends NamedSpec {
             }
 
             // The canonical base defaults to the primary class
-            if (canonicalBase == null) {
-                canonicalBase = primary;
-            } else if (!primary.isAssignableFrom(canonicalBase)) {
+            if (canonicalClass == null) {
+                canonicalClass = primary;
+            } else if (!primary.isAssignableFrom(canonicalClass)) {
                 // It must be acceptable as a self-argument
                 throw specError(CANONICAL_INCONSISTENT,
-                        canonicalBase.getSimpleName(),
+                        canonicalClass.getSimpleName(),
                         primary.getSimpleName());
             }
 
@@ -393,7 +393,7 @@ public class TypeSpec extends NamedSpec {
     }
 
     /**
-     * The class that will be the base (in Java) of classes that
+     * Specify the class that will be the base (in Java) of classes that
      * represent the instances of subclasses (in Python) of the type
      * being defined. Methods defined by the type must be able to
      * receive instances of the specified class as their {@code self}
@@ -404,18 +404,18 @@ public class TypeSpec extends NamedSpec {
      * in turn defaults to the defining class, so this method need not
      * be called in simple cases. It is useful where a class different
      * from these defaults is the base for subclasses. For example, the
-     * canonical base of {@code type} (primary class {@link PyType} is
-     * {@link SimpleType}, to ensure that metatypes have that
-     * implementation.
+     * canonical base of {@code type} is {@link SimpleType}, to ensure
+     * that metatypes have that implementation, while the primary class
+     * {@link PyType}.
      *
      * @param klass is a base for instances of every subclass
      * @return {@code this}
      */
-    public TypeSpec canonicalBase(Class<?> klass) {
-        if (canonicalBase != null) {
+    public TypeSpec canonicalClass(Class<?> klass) {
+        if (canonicalClass != null) {
             throw repeatError("canonical base class");
         }
-        this.canonicalBase = klass;
+        this.canonicalClass = klass;
         return this;
     }
 
@@ -428,13 +428,14 @@ public class TypeSpec extends NamedSpec {
     public Class<?> getPrimary() { return primary; }
 
     /**
-     * Get the canonical base class to be the base of representations of
-     * subclasses of this type. This may be {@code null} before
-     * {@link #freeze()} is called.
+     * Get the class that will be the base (in Java) of classes that
+     * represent the instances of subclasses (in Python) of the type
+     * being defined. This may be {@code null} before {@link #freeze()}
+     * is called, and by default is the same as the primary class.
      *
      * @return canonical base for instances of every subclass
      */
-    public Class<?> getCanonicalBase() { return canonicalBase; }
+    public Class<?> getCanonicalClass() { return canonicalClass; }
 
     /**
      * Specify Java classes that must be adopted by the Python type as
@@ -716,7 +717,7 @@ public class TypeSpec extends NamedSpec {
      * {@code __rsub__(MyObject, Object)} that coerces its right-hand
      * argument on each call. (This method has to exist to satisfy the
      * Python data model.) The method may be defined in the
-     * {@link #canonicalBase(Class) canonical base} class, or
+     * {@link #canonicalClass(Class) canonical base} class, or
      * {@link #methodImpls(Class...) methodImpls}.
      * <p>
      * A separate class is necessary since the method definition for
@@ -776,8 +777,8 @@ public class TypeSpec extends NamedSpec {
     public String toString() {
         String fmt = "'%s' %s %s (lookup:%s pri:%s can:%s meth:%s)";
         String pri = primary == null ? "" : primary.getSimpleName();
-        String can = canonicalBase == null ? ""
-                : canonicalBase.getSimpleName();
+        String can = canonicalClass == null ? ""
+                : canonicalClass.getSimpleName();
         String luc = lookup == null ? "null"
                 : lookup.lookupClass().getSimpleName();
         StringJoiner mic = new StringJoiner(", ", "[", "]");

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeSpec.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeSpec.java
@@ -180,11 +180,11 @@ public class TypeSpec extends NamedSpec {
      * members.
      * <p>
      * A {@code TypeSpec} given private or package access to members
-     * should not be passed to untrusted code. {@code PyType} does not
+     * should not be passed to untrusted code. The type system does not
      * hold onto the {@code TypeSpec} after completing the type object.
      *
      * @param name of the type being specified (may be dotted name)
-     * @param lookup authorisation to access {@code implClass}
+     * @param lookup authorisation to access the implementation classes
      */
     public TypeSpec(String name, Lookup lookup) {
         this(name, lookup, true);
@@ -200,7 +200,7 @@ public class TypeSpec extends NamedSpec {
      * those explicitly.
      *
      * @param name of the type being specified (may be dotted name)
-     * @param lookup authorisation to access {@code implClass}
+     * @param lookup authorisation to access the implementation classes
      * @param defaultToLookup if false, do not look for methods in the
      *     lookup class itself
      */

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeSpec.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeSpec.java
@@ -125,8 +125,8 @@ public class TypeSpec extends NamedSpec {
     /**
      * The Python type being specified may be represented by a Python
      * sub-class of {@code type}, i.e. something other than
-     * {@link PyType#TYPE}. This will be represented by a sub-class of
-     * {@link PyType}.
+     * {@link PyType#TYPE_type}. This will be represented by a sub-class
+     * of {@link PyType}.
      */
     private PyType metaclass;
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeSystem.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeSystem.java
@@ -133,6 +133,10 @@ class TypeSystem {
         // Bring the type machinery to life.
         TypeFactory f = Representation.factory;
 
+        /*
+         * It is only safe to create our first types now that the
+         * Representation class has completed static initialisation.
+         */
         @SuppressWarnings("deprecation")
         SimpleType t = Representation.factory.createTypeForType();
 
@@ -329,6 +333,7 @@ class TypeSystem {
      * @param spec specifying the new type
      * @return the new type
      */
+    // FIXME Avoid throwing InterpreterError(clash). If used at all.
     static BaseType typeFromSpec(TypeSpec spec) {
         try {
             return factory.fromSpec(spec);

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeSystem.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeSystem.java
@@ -149,11 +149,11 @@ class TypeSystem {
             registry = f.getRegistry();
 
             /*
-             * Create partial types for all the bootstrap types. These
-             * are not Python ready. All the calls to f.fromSpec() count
-             * as "re-entrant", so the type objects they create are not
-             * published, and will not be visible to any other thread
-             * yet. The process of making them Python ready is deferred,
+             * Create partial types for all the bootstrap types. All the
+             * calls to f.fromSpec() here count as "re-entrant", so the
+             * type objects they create are not published, and will not
+             * be visible to any other thread yet. The process of making
+             * them Python ready is deferred to publishBootstrapTypes,
              * and they sit in the workshop until we have defined the
              * full set.
              */
@@ -163,12 +163,11 @@ class TypeSystem {
              * PyType.fromSpec(...)' in the static initialisation of the
              * defining class. This is not safe for types needed in the
              * construction of type objects themselves. The reason is
-             * that a competing thread could seize control of the static
-             * initialisation of such a class, and would block with the
-             * necessary class half-initilised. Instead, each defining
-             * class has a nested class, not visible in the API, that
-             * provides the specification, even if some other thread has
-             * locked the defining class of that type.
+             * that a competing thread could already have seized control
+             * of the static initialisation of such a class, which would
+             * block the bootstrap. Instead, each defining class
+             * contains a package-visible Spec class, that provides the
+             * specification, even in those circumstances.
              */
 
             /*
@@ -197,12 +196,6 @@ class TypeSystem {
 
             TYPE_str = f.fromSpec(PyUnicode.Spec.get());
             TYPE_float = f.fromSpec(PyFloat.Spec.get());
-
-            /*
-             * We create 'int' before 'bool' and keep the type object,
-             * so that we may hand it to the definition of 'bool'. This
-             * thread cannot reliably reference PyLong.TYPE.
-             */
             TYPE_int = f.fromSpec(PyLong.Spec.get());
             TYPE_bool = f.fromSpec(PyBool.Spec.get(TYPE_int));
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeSystem.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeSystem.java
@@ -74,7 +74,7 @@ class TypeSystem {
     static final TypeRegistry registry;
 
     /*
-     * We use these in corresponding TYPE() methods avoid a static
+     * We use these in corresponding TYPE fields avoid a static
      * initialisation deadlock during bootstrap.
      */
     /** The type object of {@code type} objects. */
@@ -92,7 +92,6 @@ class TypeSystem {
     /** The type object of {@code wrapper_descriptor} objects. */
     static final PyType TYPE_wrapper_descriptor;
 
-    // Do we use these?
     /** The type object of {@code int} objects. */
     static final PyType TYPE_int;
     /** The type object of {@code bool} objects. */
@@ -101,6 +100,8 @@ class TypeSystem {
     static final PyType TYPE_str;
     /** The type object of {@code float} objects. */
     static final PyType TYPE_float;
+    /** The type object of the {@code None} singleton. */
+    static final PyType TYPE_NoneType;
 
     /**
      * High-resolution time (the result of {@link System#nanoTime()}) at
@@ -198,6 +199,12 @@ class TypeSystem {
             TYPE_float = f.fromSpec(PyFloat.Spec.get());
             TYPE_int = f.fromSpec(PyLong.Spec.get());
             TYPE_bool = f.fromSpec(PyBool.Spec.get(TYPE_int));
+
+            /*
+             * In order to create MethodHandles when exposing types (see
+             * static initialisation of Clinic), we also need:
+             */
+            TYPE_NoneType = f.fromSpec(PyNone.Spec.get());
 
             /*
              * We complete and publish the bootstrap types, for which

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeSystem.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeSystem.java
@@ -1,6 +1,5 @@
 package uk.co.farowl.vsj4.runtime;
 
-import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 
 import org.slf4j.Logger;
@@ -115,14 +114,6 @@ class TypeSystem {
      */
     static final long readyNanoTime;
 
-    /**
-     * A lookup with package scope. This lookup object is provided to
-     * the type factory to grant it package-level access to the run-time
-     * system.
-     */
-    private static final Lookup RUNTIME_LOOKUP =
-            MethodHandles.lookup().dropLookupMode(Lookup.PRIVATE);
-
     /*
      * The next block intends to make all the bootstrap types Java
      * ready, then Python ready, before any type object becomes visible
@@ -140,7 +131,7 @@ class TypeSystem {
         TypeFactory f = Representation.factory;
 
         @SuppressWarnings("deprecation")
-        SimpleType t = Representation.factory.typeForType();
+        SimpleType t = Representation.factory.createTypeForType();
 
         try {
             /*
@@ -214,12 +205,10 @@ class TypeSystem {
             TYPE_bool = f.fromSpec(PyBool.Spec.get(TYPE_int));
 
             /*
-             * At this point, the type factory needs access to the
-             * implementations of types in this package, and to create
-             * exposers for them.
+             * We complete and publish the bootstrap types, for which
+             * the type factory needs to create exposers.
              */
-            f.publishBootstrapTypes(RUNTIME_LOOKUP,
-                    TypeExposerImplementation::new);
+            f.publishBootstrapTypes(TypeExposerImplementation::new);
 
         } catch (Clash clash) {
             // Maybe a bootstrap type was used prematurely?

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeSystem.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeSystem.java
@@ -72,8 +72,34 @@ class TypeSystem {
      */
     static final TypeRegistry registry;
 
+    /*
+     * We use these in corresponding TYPE() methods avoid a static
+     * initialisation deadlock during bootstrap.
+     */
     /** The type object of {@code type} objects. */
-    static final PyType TYPE;
+    static final PyType TYPE_type;
+    /** The type object of {@code getset_descriptor}. */
+    static final PyType TYPE_getset_descriptor;
+    /** The type object of {@code builtin_function_or_method}. */
+    static final PyType TYPE_builtin_function_or_method;
+    /** The type object of {@code member_descriptor} objects. */
+    static final PyType TYPE_member_descriptor;
+    /** The type object of {@code method_descriptor} objects. */
+    static final PyType TYPE_method_descriptor;
+    /** The type object of {@code method-wrapper} objects. */
+    static final PyType TYPE_method_wrapper;
+    /** The type object of {@code wrapper_descriptor} objects. */
+    static final PyType TYPE_wrapper_descriptor;
+
+    // Do we use these?
+    /** The type object of {@code int} objects. */
+    static final PyType TYPE_int;
+    /** The type object of {@code bool} objects. */
+    static final PyType TYPE_bool;
+    /** The type object of {@code str} objects. */
+    static final PyType TYPE_str;
+    /** The type object of {@code float} objects. */
+    static final PyType TYPE_float;
 
     /**
      * High-resolution time (the result of {@link System#nanoTime()}) at
@@ -125,7 +151,7 @@ class TypeSystem {
              * this thread leaves the static initialisation of
              * TypeSystem.
              */
-            TYPE = t;
+            TYPE_type = t;
             factory = f;
             registry = f.getRegistry();
 
@@ -156,12 +182,18 @@ class TypeSystem {
              * The first types needing this consideration are the
              * descriptors.
              */
-            f.fromSpec(PyGetSetDescr.Spec.get());
-            f.fromSpec(PyJavaFunction.Spec.get());
-            f.fromSpec(PyMemberDescr.Spec.get());
-            f.fromSpec(PyMethodDescr.Spec.get());
-            f.fromSpec(PyMethodWrapper.Spec.get());
-            f.fromSpec(PyWrapperDescr.Spec.get());
+            TYPE_getset_descriptor =
+                    f.fromSpec(PyGetSetDescr.Spec.get());
+            TYPE_builtin_function_or_method =
+                    f.fromSpec(PyJavaFunction.Spec.get());
+            TYPE_member_descriptor =
+                    f.fromSpec(PyMemberDescr.Spec.get());
+            TYPE_method_descriptor =
+                    f.fromSpec(PyMethodDescr.Spec.get());
+            TYPE_method_wrapper =
+                    f.fromSpec(PyMethodWrapper.Spec.get());
+            TYPE_wrapper_descriptor =
+                    f.fromSpec(PyWrapperDescr.Spec.get());
 
             /*
              * The second group of types is those with adopted
@@ -170,16 +202,16 @@ class TypeSystem {
              * "discovered" type for Integer.
              */
 
-            f.fromSpec(PyUnicode.Spec.get());
-            f.fromSpec(PyFloat.Spec.get());
+            TYPE_str = f.fromSpec(PyUnicode.Spec.get());
+            TYPE_float = f.fromSpec(PyFloat.Spec.get());
 
             /*
              * We create 'int' before 'bool' and keep the type object,
-             * so that we may hand it to the definition of 'bool'.
-             * This thread cannot reliably reference PyLong.TYPE.
+             * so that we may hand it to the definition of 'bool'. This
+             * thread cannot reliably reference PyLong.TYPE.
              */
-            final PyType INT = f.fromSpec(PyLong.Spec.get());
-            f.fromSpec(PyBool.Spec.get(INT));
+            TYPE_int = f.fromSpec(PyLong.Spec.get());
+            TYPE_bool = f.fromSpec(PyBool.Spec.get(TYPE_int));
 
             /*
              * At this point, the type factory needs access to the

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeSystem.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/TypeSystem.java
@@ -1,3 +1,5 @@
+// Copyright (c)2025 Jython Developers.
+// Licensed to PSF under a contributor agreement.
 package uk.co.farowl.vsj4.runtime;
 
 import java.lang.invoke.MethodHandles.Lookup;

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/WithClassAssignment.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/WithClassAssignment.java
@@ -28,22 +28,23 @@ public interface WithClassAssignment extends WithClass {
      * Called during {@code __class__} assignment (that is, during the
      * implementation of {@link #setType(Object)} or a constructor) to
      * check that the object being assigned is acceptable. It is only
-     * acceptable if the representation class of the proposed type is
-     * exactly the class of this object. The declared type of
-     * {@code type} is {@code Object} to simplify exposure to Python via
-     * {@code __setattr__}.
+     * acceptable if the replacement type and the existing type specify
+     * the same representation class for their instances. The declared
+     * type of {@code type} is {@code Object} to simplify exposure to
+     * Python via {@code __setattr__} but it has to be a (replaceable)
+     * Python {@code type} object.
      *
      * @param replacementType intended new type object
      * @return argument cast to {@link PyType} (if no error raised)
-     * @throws PyBaseException if replacement is unacceptable
+     * @throws PyBaseException (TypeError) if replacement unacceptable
      */
     default PyType checkClassAssignment(Object replacementType) {
         PyType type = getType();
-        if (type != null) {
-            return PyUtil.checkReplaceable(type, replacementType);
-        } else {
+        if (type == null) {
             // Possible when checking initial assignment to __class__
             return PyUtil.checkReplaceable(getClass(), replacementType);
+        } else {
+            return PyUtil.checkReplaceable(type, replacementType);
         }
     }
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/WithClassAssignment.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/WithClassAssignment.java
@@ -26,36 +26,25 @@ public interface WithClassAssignment extends WithClass {
 
     /**
      * Called during {@code __class__} assignment (that is, during the
-     * implementation of {@link #setType(Object)}) to check that the
-     * object being assigned is acceptable. It is only acceptable if the
-     * representation class of the proposed type is exactly the class of
-     * this object. The declared type of {@code type} is {@code Object}
-     * to simplify exposure to Python via {@code __setattr__}.
+     * implementation of {@link #setType(Object)} or a constructor) to
+     * check that the object being assigned is acceptable. It is only
+     * acceptable if the representation class of the proposed type is
+     * exactly the class of this object. The declared type of
+     * {@code type} is {@code Object} to simplify exposure to Python via
+     * {@code __setattr__}.
      *
      * @param replacementType intended new type object
      * @return argument cast to {@link PyType} (if no error raised)
+     * @throws PyBaseException if replacement is unacceptable
      */
     default PyType checkClassAssignment(Object replacementType) {
-        String msg;
-        if (replacementType == null) {
-            msg = "__class__ attribute cannot be deleted";
-        } else if (replacementType instanceof PyType t) {
-            if (this.getClass() == t.javaClass()) {
-                // t = replacementType is an acceptable type
-                return t;
-            }
-            // Failing to assign as representations differ
-            // Note current type may be null (e.g. in constructor).
-            PyType type = this.getType();
-            msg = String.format(
-                    "__class__ assignment: '%s' representation differs from %s",
-                    t.getName(), type == null ? "chosen implementation"
-                            : "that of '" + type.getName() + "'");
+        PyType type = getType();
+        if (type != null) {
+            return PyUtil.checkReplaceable(type, replacementType);
         } else {
-            msg = String.format(
-                    "__class__ must be set to a class, not a '%s' object",
-                    PyType.of(replacementType).getName());
+            // Possible when checking initial assignment to __class__
+            return PyUtil.checkReplaceable(getClass(), replacementType);
         }
-        throw PyErr.format(PyExc.TypeError, msg);
     }
+
 }

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/internal/NamedSpec.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/internal/NamedSpec.java
@@ -2,6 +2,8 @@
 // Licensed to PSF under a contributor agreement.
 package uk.co.farowl.vsj4.runtime.internal;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import uk.co.farowl.vsj4.support.InterpreterError;
@@ -12,10 +14,14 @@ import uk.co.farowl.vsj4.support.InterpreterError;
  */
 public abstract class NamedSpec {
 
-    /** Unmodifiable empty list. */
-    protected static final List<Class<?>> EMPTY = List.of();
-    /** Unmodifiable empty list. */
-    protected static final List<String> NONAMES = List.of();
+    /** Unmodifiable empty list (or sentinel for "never assigned"). */
+    protected static final List<Class<?>> EMPTY =
+            // Not List.of() because identity of object is significant.
+            Collections.unmodifiableList(new ArrayList<>());
+    /** Unmodifiable empty list (or sentinel for "never assigned"). */
+    protected static final List<String> NONAMES =
+            // Not List.of() because identity of object is significant.
+            Collections.unmodifiableList(new ArrayList<>());
 
     /** Simple name of the representation class. */
     protected String name;
@@ -37,13 +43,12 @@ public abstract class NamedSpec {
      */
     protected NamedSpec(String name) { this.name = name; }
 
-    /** Return name specified to constructor.
+    /**
+     * Return name specified to constructor.
      *
      * @return name of specified object
      */
-    public String getName() {
-        return name;
-    }
+    public String getName() { return name; }
 
     /** Check that {@link #freeze()} has not yet been called. */
     protected void checkNotFrozen() {

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/internal/NamedSpec.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/internal/NamedSpec.java
@@ -60,8 +60,8 @@ public abstract class NamedSpec {
      */
     protected InterpreterError specError(String err, Object... args) {
         StringBuilder sb = new StringBuilder(100);
-        sb.append(String.format(err, args)).append(" while defining '")
-                .append(name).append("'.");
+        sb.append(String.format(err, args)).append(" (defining '")
+                .append(name).append("').");
         return new InterpreterError(sb.toString());
     }
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/internal/Singleton.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/internal/Singleton.java
@@ -39,12 +39,15 @@ public abstract class Singleton implements WithClass {
 
     // Special methods -----------------------------------------------
 
+    /*
+     * Special methods are public, so as to be visible from runtime
+     * package (not API).
+     */
+
     /**
      * {@code __repr__}
      *
      * @return {@code repr(this)} as defined in constructor.
      */
-    protected Object __repr__() {
-        return name;
-    }
+    public Object __repr__() { return name; }
 }

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/internal/_PyUtil.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/internal/_PyUtil.java
@@ -264,5 +264,4 @@ public class _PyUtil {
         return PyErr.format(PyExc.TypeError,
                 "can't set attributes of %.200s", obj);
     }
-
 }

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/internal/_PyUtil.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/internal/_PyUtil.java
@@ -7,6 +7,7 @@ import java.util.StringJoiner;
 
 import uk.co.farowl.vsj4.runtime.Abstract;
 import uk.co.farowl.vsj4.runtime.ArgumentError;
+import uk.co.farowl.vsj4.runtime.Callables;
 import uk.co.farowl.vsj4.runtime.FastCall;
 import uk.co.farowl.vsj4.runtime.Py;
 import uk.co.farowl.vsj4.runtime.PyAttributeError;
@@ -15,7 +16,6 @@ import uk.co.farowl.vsj4.runtime.PyErr;
 import uk.co.farowl.vsj4.runtime.PyExc;
 import uk.co.farowl.vsj4.runtime.PyType;
 import uk.co.farowl.vsj4.runtime.PyUtil;
-import uk.co.farowl.vsj4.support.internal.EmptyException;
 import uk.co.farowl.vsj4.support.internal.Util;
 
 /**
@@ -62,14 +62,16 @@ public class _PyUtil {
     }
 
     /**
-     * Call a Python object when the first argument {@code arg0} is
+     * Call a Python object when the first argument {@code self} is
      * provided "loose". This is a frequent need when that argument is
      * the {@code self} object in a method call. The call effectively
-     * prepends {@code arg0} to {@code args}. It does no attribute
+     * prepends {@code self} to {@code args}. It will use the
+     * {@link FastCall} interface to avoid actually prepending to an
+     * array if the {@code callable} supports it. It does no attribute
      * binding.
      *
      * @param callable a Python callable target
-     * @param arg0 the first argument
+     * @param self the first argument
      * @param args arguments from 1 (position then keyword)
      * @param names of the keyword arguments or {@code null}
      * @return the return from the call to the object
@@ -77,58 +79,45 @@ public class _PyUtil {
      * @throws Throwable for errors raised in the function
      */
     // Compare CPython _PyObject_Call_Prepend in call.c
-    public static Object callPrepend(Object callable, Object arg0,
+    public static Object callPrepend(Object callable, Object self,
             Object[] args, String[] names)
             throws PyBaseException, Throwable {
-
-        // Speed up the common idiom:
-        // if (names == null || names.length == 0) ...
-        if (names != null && names.length == 0) { names = null; }
 
         if (callable instanceof FastCall fast) {
             // Fast path recognising optimised callable
             try {
-                return fast.call(arg0, args, names);
+                if (names == null || names.length == 0) {
+                    // No arguments by keyword
+                    switch (args.length) {
+                        case 0:
+                            return fast.call(self);
+                        case 1:
+                            return fast.call(self, args[0]);
+                        case 2:
+                            return fast.call(self, args[0], args[1]);
+                        case 3:
+                            return fast.call(self, args[0], args[1],
+                                    args[2]);
+                        default:
+                            // Ensure args is treated as an array
+                            return fast.call(self, args, null);
+                    }
+                } else {
+                    // Some arguments by keyword
+                    return fast.call(self, args, names);
+                }
             } catch (ArgumentError ae) {
                 // TypeError needs full argument list to make sense.
-                Object[] a = Util.prepend(arg0, args);
+                Object[] a = Util.prepend(self, args);
                 throw fast.typeError(ae, a, names);
             }
+
         } else {
-            // Go via callable.__call__
-            Object[] a = Util.prepend(arg0, args);
-            return _PyUtil.standardCall(callable, a, names);
+            // Go via callable.__call__ special method
+            Object[] a = Util.prepend(self, args);
+            return Callables.standardCall(callable, a, names);
         }
     }
-
-    /**
-     * Call an object with the standard protocol, via the
-     * {@code __call__} special method.
-     *
-     * @param callable target
-     * @param args all the arguments (position then keyword)
-     * @param names of the keyword arguments or {@code null}
-     * @return the return from the call to the object
-     * @throws PyBaseException (TypeError) if target is not callable
-     * @throws Throwable for errors raised in the function
-     */
-    public static Object standardCall(Object callable, Object[] args,
-            String[] names) throws PyBaseException, Throwable {
-
-        try {
-            // Call via the special method
-            // XXX Stop gap code until support for special functions
-            // Object o = PyType.of(callable).lookup("__call__");
-
-            throw new EmptyException();
-
-        } catch (EmptyException e) {
-            throw Abstract.typeError(OBJECT_NOT_CALLABLE, callable);
-        }
-    }
-
-    private static final String OBJECT_NOT_CALLABLE =
-            "'%.200s' object is not callable";
 
     /**
      * Create a {@link PyAttributeError} with a message along the lines
@@ -253,6 +242,7 @@ public class _PyUtil {
         return (PyAttributeError)PyErr.format(PyExc.AttributeError, fmt,
                 type.getName(), name);
     }
+
     /**
      * Create a {@link PyBaseException TypeError} with a message along
      * the lines "can't set attributes of X" giving str of {@code name}.

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/BaseType.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/BaseType.java
@@ -11,6 +11,7 @@ import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -19,10 +20,16 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import uk.co.farowl.vsj4.runtime.Abstract;
 import uk.co.farowl.vsj4.runtime.ArgumentError;
 import uk.co.farowl.vsj4.runtime.Callables;
 import uk.co.farowl.vsj4.runtime.Exposed;
+import uk.co.farowl.vsj4.runtime.Exposed.KeywordCollector;
 import uk.co.farowl.vsj4.runtime.Feature;
 import uk.co.farowl.vsj4.runtime.MethodDescriptor;
 import uk.co.farowl.vsj4.runtime.PyAttributeError;
@@ -42,6 +49,9 @@ import uk.co.farowl.vsj4.runtime.TypeFlag;
 import uk.co.farowl.vsj4.runtime.TypeSpec;
 import uk.co.farowl.vsj4.runtime.WithDict;
 import uk.co.farowl.vsj4.runtime.internal._PyUtil;
+import uk.co.farowl.vsj4.runtime.kernel.TypeFactory.Clash;
+import uk.co.farowl.vsj4.runtime.subclass.SubclassFactory;
+import uk.co.farowl.vsj4.runtime.subclass.SubclassSpec;
 import uk.co.farowl.vsj4.support.InterpreterError;
 import uk.co.farowl.vsj4.support.internal.EmptyException;
 
@@ -60,6 +70,14 @@ import uk.co.farowl.vsj4.support.internal.EmptyException;
  */
 public abstract sealed class BaseType extends KernelType
         permits SimpleType, ReplaceableType, AdoptiveType {
+
+    /** Logger for type object activity in the kernel. */
+    protected static final Logger logger =
+            LoggerFactory.getLogger(BaseType.class);
+
+    /** Subclass factory} to use in creating subclasses. */
+    static final SubclassFactory SUBCLASS_FACTORY =
+            new SubclassFactory("VSJ$%s$%d");
 
     /**
      * The {@code __mro__} of this type, that is, the method resolution
@@ -332,14 +350,142 @@ public abstract sealed class BaseType extends KernelType
      *
      * @param t presented to our API somewhere
      * @return {@code t} if it is a {@code BaseType}
-     * @throws ClassCastException {@code t} is not a {@code BaseType}
+     * @throws PyBaseException {@code t} is not a {@code BaseType}
      */
-    public static BaseType cast(PyType t) throws InterpreterError {
+    public static BaseType cast(Object t)
+            throws PyBaseException, ClassCastException {
         if (t instanceof BaseType bt) {
             return bt;
-        } else {
+        } else if (t instanceof PyType) {
             throw new ClassCastException(String.format(
                     "non-Jython PyType encountered: %s", t.getClass()));
+        } else {
+            throw Abstract.requiredTypeError("a type", t);
+        }
+    }
+
+    // Constructor from Python ----------------------------------------
+
+    /**
+     * Create a new instance of Python {@code type}, or of a subclass
+     * {@code M}. The actual Python type of the returned object may be a
+     * subclass {@code M} or a subclass of that, as required by the
+     * bases.
+     * <p>
+     * Note the following cases. Suppose {@code T} to be a superclass of
+     * {@code M}, and a subclass of {@code type}, that has not
+     * overridden {@code __new__}. We may arrive here:
+     * <ul>
+     * <li>directly as a call to {@code T.__new__(M, name, bases, ns)},
+     * or</li>
+     * <li>from a call {@code M(name, bases, ns)}, where {@code M} does
+     * not override {@code __call__} or {@code __new__}, which resolves
+     * {@code M.__new__} to call this method.</li>
+     * <li>indirectly, beginning with either
+     * {@code M.__new__(M, name, bases, ns)} or
+     * {@code M(name, bases, ns)}, but where {@code M} overrides
+     * {@code __new__}, and we arrive by one or more calls to
+     * {@code super().__new__(M, name, bases, ns)}.</li>
+     * </ul>
+     * The internal logic of {@code __new__} is subtle enough to do the
+     * right thing in these various cases.
+     * <p>
+     * Note that {@code class A: pass} produces a new instance of
+     * {@code type}, while {@code class T(A,B,metaclass=M)}: pass
+     * produces a new instance of {@code M}, which must be a Python
+     * sub-type of {@code type}.
+     *
+     * @param cls requested Python sub-class being created (a metaclass)
+     * @param name to be reported by the type object
+     * @param bases specified for the type object
+     * @param namespace initially specified elements for the namespace
+     *     of the class
+     * @param kwargs keyword arguments given to {@code __new__}
+     * @return a newly-created type.
+     * @throws PyBaseException (TypeError) When the type specification
+     *     implied by the arguments is not realisable for reasons given
+     *     in the exception.
+     * @throws Throwable from other errors
+     */
+    // Compare CPython type_new in typeobject.c
+    @Exposed.PythonNewMethod
+    public static Object __new__(PyType cls, String name, PyTuple bases,
+            PyDict namespace, @KeywordCollector PyDict kwargs)
+            throws PyBaseException, Throwable {
+        // FIXME type.__new__ currently ignoring keyword arguments
+
+        // Make a list of the bases, checking they are acceptable
+        List<BaseType> checkedBases = updateBases(bases, () -> PyErr
+                .format(PyExc.TypeError, MRO_ENTRIES_NOT_SUPPORTED));
+
+        // From cls and the bases, choose a common metaclass.
+        BaseType metaclass =
+                commonMetaclass(BaseType.cast(cls), checkedBases);
+
+        // FIXME Support the several cases within type.__new__
+
+        /*
+         * 1. metaclass is exactly type and so is the metaclass of every
+         * base: we produce a new instance of BaseType with a
+         * representation that subclasses the representation of every
+         * base.
+         */
+
+        /*
+         * 1. There is a common metaclass, that is a proper subclass of
+         * metaclass, for which __new__ is not type.__new__: we shall
+         * call that to create the new type, instead of creating a new
+         * type within this call. However, this in turn (directly or
+         * not) should call type.__new__ with cls as the common
+         * metaclass. Therefore we will arrive here again, maybe with
+         * different arguments.
+         */
+
+        /*
+         * 3. The common metaclass is exactly metaclass: we shall create
+         * a new type within this call, setting its type to metaclass,
+         * but we do not call metaclass.__new__, (even if
+         * metaclass.__new__ != type.__new__) as we assume we are
+         * already inside such a call.
+         */
+
+        /*
+         * 4. There is a common metaclass, which may be exactly
+         * metaclass, or a proper subclass of it, for which __new__ is
+         * type.__new__: we shall create a new type within this call,
+         * setting its type to the common metaclass.
+         */
+
+        /*
+         * When no bases are given, the effective base is just object.
+         * This is a special case of 2.
+         */
+
+        /*
+         * We must find or create a class capable of representing
+         * instances of this type.
+         */
+        BaseType bestBase = best_base(checkedBases);
+        SubclassSpec instanceSpec =
+                new SubclassSpec(name, bestBase.canonicalClass());
+        // TODO are constructors more a property of a Representation?
+        instanceSpec.addConstructors(bestBase);
+        // Creating the class give it to us with access privileges.
+        Lookup lu = SUBCLASS_FACTORY.findOrCreateSubclass(instanceSpec);
+
+        /*
+         * We create the type object required using the TypeFactory,
+         * with the new synthetic class as the representation.
+         */
+        TypeSpec spec = new TypeSpec(name, lu).bases(checkedBases)
+                .metaclass(metaclass).namespace(namespace)
+                .add(Feature.REPLACEABLE, Feature.BASETYPE);
+        try {
+            BaseType type = factory.fromSpec(spec);
+            return type;
+        } catch (Clash e) {
+            // TODO Interpret as a type error?
+            throw new InterpreterError(e);
         }
     }
 
@@ -630,16 +776,17 @@ public abstract sealed class BaseType extends KernelType
     @Override
     public Object call(Object[] args, String[] names)
             throws ArgumentError, Throwable {
+
+        assert (args != null);
+        int nk = names == null ? 0 : names.length;
+        int np = args.length - nk;
+
         /*
          * Special case: type(x) should return the Python type of x, but
          * only if this is exactly the type 'type'.
          */
-        if (this == PyType.TYPE()) {
+        if (this == typeType()) {
             // Deal with two special cases
-            assert (args != null);
-            int nk = names == null ? 0 : names.length;
-            int np = args.length - nk;
-
             if (np == 1 && nk == 0) {
                 // Call is exactly type(x) so this is a type enquiry
                 return PyType.of(args[0]);
@@ -1091,6 +1238,14 @@ public abstract sealed class BaseType extends KernelType
 
     // plumbing ------------------------------------------------------
 
+    private static final String MRO_ENTRIES_NOT_SUPPORTED =
+            "type() doesn't support MRO entry resolution; "
+                    + "use types.new_class()";
+    private static final String METACLASS_CONFLICT =
+            "metaclass conflict: " + "the metaclass of a derived class "
+                    + "must be a (non-strict) subclass "
+                    + "of the metaclasses of all its bases";
+
     /**
      * Determine if this type is a Python sub-type of {@code b} by
      * chaining through the {@link #base} property. (This is a fall-back
@@ -1101,6 +1256,11 @@ public abstract sealed class BaseType extends KernelType
      */
     // Compare CPython type_is_subtype_base_chain in typeobject.c
     private boolean type_is_subtype_base_chain(PyType b) {
+        // Useful to know when we resort to this
+        logger.atTrace()
+                .setMessage("ask {} is sub-type of {} from base chain")
+                .addArgument(() -> getName())
+                .addArgument(() -> b.getName());
         PyType t = this;
         while (t != b) {
             t = t.getBase();
@@ -1111,10 +1271,11 @@ public abstract sealed class BaseType extends KernelType
 
     /**
      * Invoke a custom {@code mro()}, if one has been defined for this
-     * type, or do the equivalent of {@link #mro()} if not. The method
-     * is safe to use during type system initialisation, when bootstrap
-     * types are still being created. A custom {@code mro()} cannot have
-     * been defined by then, and so the alternate path is always taken.
+     * type, or do the equivalent of {@link #mro()} if not.
+     * <p>
+     * The method is safe to use during type system initialisation where
+     * {@link #getType()}{@code ==type}, that is, this is not a Python
+     * metaclass.
      *
      * @return a valid MRO for the type
      * @throws Throwable on Python errors
@@ -1122,9 +1283,10 @@ public abstract sealed class BaseType extends KernelType
     // Compare CPython mro_invoke in typeobject.c
     // Unlike CPython, we return an array, avoiding PyTuple.
     private BaseType[] mro_invoke() throws Throwable {
-
+        logger.atDebug().setMessage("calculating __mro__ of {}")
+                .addArgument(name).log();
         BaseType[] newMRO = null;
-        SimpleType typeType = getTypeForType();
+        SimpleType typeType = typeType();
         // FIXME getType() of concrete PyTypes should be concrete
         // This will affect the synthesis of sub-type representations
         BaseType metatype = BaseType.cast(getType());
@@ -1136,6 +1298,8 @@ public abstract sealed class BaseType extends KernelType
                  * This is a metatype that redefines mro(). We call its
                  * specific mro() as a Python method.
                  */
+                logger.atDebug().setMessage("calling {}")
+                        .addArgument(lur.obj).log();
                 Object mro_result = Callables.call(lur.obj, this);
                 // It returns some kind of iterable.
                 List<Object> result = PySequence.fastList(mro_result,
@@ -1230,13 +1394,197 @@ public abstract sealed class BaseType extends KernelType
     private BaseType solid_base() {
         // Walk the base chain and return just before the class change.
         BaseType sb;
-        if (base != null) {
+        if (base != null) {  // TODO: is recursion sensible here? Loop?
             sb = base.solid_base();
         } else {
             // This must be the type object of object
             return this;
         }
         return javaClass() == sb.javaClass() ? sb : this;
+    }
+
+    /**
+     * Calculate the "best base" amongst multiple base classes. A type
+     * that has the given types as bases will have as its "best base"
+     * the first base with a representation in Java that is a sub-class
+     * of the representations of all the bases.
+     * <p>
+     * When defining a new type with these bases, the appropriate
+     * representation Java class may be that of the "best base", or it
+     * may be one that extends that representation, e.g to accommodate
+     * new members ({@code __slots__} or an instance dictionary). It
+     * follows, however, that the representation of the new type will be
+     * a Java subclass of the representations of all the bases, and
+     * therefore their operations apply to the new type.
+     * <p>
+     * If no such candidate is found amongst the bases, the
+     * representations are said to conflict, and the type cannot exist
+     * in this implementation. (CPython calls this a "layout conflict".
+     * We think the logic here is no more restrictive than in CPython.)
+     *
+     * @param bases of a potential new type
+     * @return the best amongst them as a base for representations
+     */
+    // Compare CPython best_base in typeobject.c
+    private static BaseType best_base(List<BaseType> bases) {
+        BaseType base = objectType(), winner = base;
+
+        for (PyType pt : bases) {
+            BaseType b = BaseType.cast(pt);
+            assert b.isReady();
+
+            // TODO: did we not check for BASETYPE already?
+            if (!b.hasFeature(TypeFlag.BASETYPE)) {
+                throw PyErr.format(PyExc.TypeError,
+                        "type '%.100s' is not an acceptable base type",
+                        b.getName());
+            }
+
+            // The candidate has the same representation as b
+            BaseType candidate = b.solid_base();
+
+            if (winner.isSubTypeOf(candidate)) {
+                // Don't change the candidate
+            } else if (candidate.isSubTypeOf(winner)) {
+                // candidate is more derived so is new winner
+                winner = candidate;
+                base = b;
+            } else {
+                throw PyErr.format(PyExc.TypeError,
+                        "bases have conflicting representations");
+            }
+        }
+
+        // base will be object type if bases was empty
+        return base;
+    }
+
+    /**
+     * Determine the proper metaclass to construct a new type, given
+     * that the metaclass and bases originally specified, in an
+     * expression like {@code class C(bases, metaclass=m):pass} or as
+     * the function called as {@code m(name, bases, {})}. The proper
+     * metaclass is a Python sub-class of the given metatype and the
+     * types of all the bases.
+     * <p>
+     * At the same time, we check for metaclass conflicts and bases that
+     * are not types at all.
+     *
+     * @param metaclass specified originally
+     * @param bases of the new type
+     * @return proper metaclass to create new type (not {@code null})
+     */
+    // Compare CPython _PyType_CalculateMetaclass in typeobject.c
+    private static BaseType commonMetaclass(BaseType metaclass,
+            List<BaseType> bases) {
+        for (BaseType base : bases) {
+            // FIXME: specialise getType to avoid the cast
+            // This means reworking type attribute in SubclassFactory
+            BaseType candidate = (BaseType)base.getType();
+            if (metaclass.isSubTypeOf(candidate)) {
+                // Don't change the winning metaclass
+            } else if (candidate.isSubTypeOf(metaclass)) {
+                // candidate is the new winner
+                metaclass = candidate;
+            } else {
+                throw PyErr.format(PyExc.TypeError, METACLASS_CONFLICT);
+            }
+        }
+        return metaclass;
+    }
+
+    /**
+     * Make a list of the bases from the {@code args}, checking that
+     * each is acceptable as a base (is a {@link BaseType} and allows
+     * itself to be a base in Python. This method may be used in
+     * {@code type.__new__} and also {@code builtins.__build_class__}.
+     * <p>
+     * In the latter context, objects are allowed that resolve to a
+     * tuple of bases using the {@code __mro_entries__} protocol, and
+     * this method makes that expansion. In the former context,
+     * {@code type.__new__} forbids this by providing a non null
+     * {@code exceptionSupplier}.
+     *
+     * @param spec to accumulate the bases.
+     * @param args purported bases.
+     * @param exceptionSupplier if not {@code null},
+     *     {@code __mro_entries__} protocol is forbidden.
+     * @throws PyBaseException (TypeError) when some object in
+     *     {@code args} cannot be a base.
+     * @throws Throwable from other errors in the implementation of the
+     *     tuple etc..
+     */
+    // Compare CPython update_bases in bltinmodule.c
+    // Compare CPython type_new_get_bases in typeobject.c
+    private static List<BaseType> updateBases(PyTuple args,
+            Supplier<PyBaseException> exceptionSupplier)
+            throws PyBaseException, Throwable {
+
+        // Almost always the same size as args.
+        List<BaseType> bases = new ArrayList<>(args.size());
+
+        for (Object arg : args) {
+
+            if (arg instanceof BaseType base) {
+                addChecked(bases, base);
+
+            } else {
+                // Non-type object: does it implement __mro_entries__?
+                Object meth = null, entries = null;
+                try {
+                    meth = Abstract.lookupAttr(arg, "__mro_entries__");
+                } catch (Throwable e) {
+                    // Treat as not found.
+                }
+
+                if (meth != null) {
+                    /*
+                     * We are expected to call __mro_entries__, and
+                     * replace arg with the entries it provides. But
+                     * first, is that allowed here?
+                     */
+                    if (exceptionSupplier != null) {
+                        // No: throw as specified by the caller.
+                        throw exceptionSupplier.get();
+                    } else {
+                        /*
+                         * __mro_entries__ expects the original args as
+                         * its argument and returns a tuple of types
+                         */
+                        entries = Callables.call(meth, args);
+
+                        // And should return a tuple of types.
+                        if (entries instanceof PyTuple t) {
+                            for (Object o : t) { addChecked(bases, o); }
+                        } else {
+                            throw PyErr.format(PyExc.TypeError,
+                                    "__mro_entries__ must return a tuple");
+                        }
+                    }
+                }
+            }
+        }
+        return bases;
+    }
+
+    private static void addChecked(List<BaseType> bases, Object o) {
+        if (o instanceof PyType base) {
+            // Diagnose foreign PyType implementations here
+            addChecked(bases, BaseType.cast(base));
+        } else {
+            throw PyErr.format(PyExc.TypeError, "bases must be types");
+        }
+    }
+
+    private static void addChecked(List<BaseType> bases,
+            BaseType base) {
+        if (base.hasFeature(TypeFlag.BASETYPE)) {
+            bases.add(base);
+        } else {
+            throw PyErr.format(PyExc.TypeError,
+                    "type '%.100s' is not an acceptable base type",
+                    base);
+        }
     }
 
     /**

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/BaseType.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/BaseType.java
@@ -1224,7 +1224,7 @@ public abstract sealed class BaseType extends KernelType implements
         Map<MethodType, ConstructorAndHandle> table = new HashMap<>();
         // We allow public construction only of the canonical base.
         // (This is right for use by __new__ ... and generally?)
-        Class<?> baseClass = spec.getCanonicalBase();
+        Class<?> baseClass = spec.getCanonicalClass();
         Lookup lookup = spec.getLookup();
         final int accept = Modifier.PUBLIC | Modifier.PROTECTED;
         for (Constructor<?> cons : baseClass

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/BaseType.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/BaseType.java
@@ -1200,13 +1200,12 @@ public abstract sealed class BaseType extends KernelType implements
              * This method is really here for __new__ implementations,
              * and has to be public because they could be in any
              * package. So, stuff can go wrong. But how to explain to
-             * the hapless caller when something is really a Java API
-             * error?
+             * the hapless caller when something is probably a Java API
+             * error in the synthetic class?
              */
-            // TODO Need a Java API Error not InterpreterError
             throw PyErr.format(PyExc.TypeError,
-                    "Incorrect arguments to constructor of '%s'",
-                    getName());
+                    "No public constructor of '%s' matches %s",
+                    getName(), mt);
         }
         return ch;
     }

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/KernelType.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/KernelType.java
@@ -49,7 +49,8 @@ public abstract class KernelType extends Representation
      * <p>
      * It is the type earliest on the MRO after the current type, whose
      * implementation contains all the members necessary to implement
-     * the current type.
+     * the current type. It is {@code null} (exposed as {@code None})
+     * only on the type object for {@code object}.
      */
     protected BaseType base;
 
@@ -113,7 +114,7 @@ public abstract class KernelType extends Representation
     public PyType getBase() { return base; }
 
     @Override
-    public PyType getType() { return PyType.TYPE(); }
+    public PyType getType() { return getTypeForType(); }
 
     /**
      * Return a copy of the MRO of this type.

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/KernelType.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/KernelType.java
@@ -300,6 +300,27 @@ public abstract class KernelType extends Representation
     }
 
     /**
+     * Check that this type is Python-ready, that is, it has been marked
+     * as fit to be handled outside the type system. An immutable type
+     * becomes ready at the end of construction and stays that way. A
+     * mutable type may go through periods when it is not Python-ready,
+     * while it is internally inconsistent, or inconsistent with related
+     * data. Correct synchronisation will ensure it does not escape in
+     * that condition.
+     * <p>
+     * Ideally, this method only appears in {@code assert} statements
+     * and unit tests. Operations on types that are not Python-ready
+     * should block until they are. If we have to consult this as a
+     * basis for run-time decisions, something is amiss with the design.
+     *
+     * @return target is a Python-ready
+     */
+    // Compare CPython PySequence_Check (on instance) in abstract.c
+    public boolean isReady() {
+        return kernelFeatures.contains(KernelTypeFlag.READY);
+    }
+
+    /**
      * Determine if this type is a Python sub-type of {@code b} (if
      * {@code b} is on the MRO of this type). For technical reasons we
      * parameterise with the subclass. (We need it to work with a

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/KernelType.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/KernelType.java
@@ -1,3 +1,5 @@
+// Copyright (c)2025 Jython Developers.
+// Licensed to PSF under a contributor agreement.
 package uk.co.farowl.vsj4.runtime.kernel;
 
 import java.lang.invoke.MethodType;

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/KernelType.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/KernelType.java
@@ -115,8 +115,16 @@ public abstract class KernelType extends Representation
     @Override
     public PyType getBase() { return base; }
 
+    /**
+     * @implNote {@code type} will do as the default, but in
+     *     {@link SimpleType} and {@link ReplaceableType} we must store
+     *     and return an actual type, that may be some sub-type of
+     *     {@code type}, and therefore (by the way) an instance of a
+     *     Java sub-class of {@link BaseType}.
+     */
+    // FIXME: override in subclasses so not always exactly 'type'
     @Override
-    public PyType getType() { return getTypeForType(); }
+    public PyType getType() { return typeType(); }
 
     /**
      * Return a copy of the MRO of this type.
@@ -320,37 +328,7 @@ public abstract class KernelType extends Representation
         return kernelFeatures.contains(KernelTypeFlag.READY);
     }
 
-    /**
-     * Determine if this type is a Python sub-type of {@code b} (if
-     * {@code b} is on the MRO of this type). For technical reasons we
-     * parameterise with the subclass. (We need it to work with a
-     * private superclass or {@code PyType}.)
-     *
-     * @param b to test
-     * @return {@code true} if {@code this} is a sub-type of {@code b}
-     */
-    // Compare CPython PyType_IsSubtype in typeobject.c
-    // TODO: Make this take a PyType when we sort out the hierarchy
-    // Probably implement in BaseType
-    public boolean isSubTypeOf(KernelType b) { return false; }
-
     // Support for __new__ -------------------------------------------
-
-/// **
-// * The return from {@link #constructor()} holding a reflective
-// * constructor definition and a handle by which it may be called.
-// * <p>
-// * A custom {@code __new__} method in a defining Java class of a
-// * type generally has direct access to all the constructors it needs
-// * for its own type. When asked for an instance of a different type,
-// * it must be able to call the constructor of the Java
-// * representation class. The representation of the required type
-// * (the {@code cls} argument to {@code __new__}) will be a subclass
-// * in Java of the canonical representation of the type from which
-// * {@code __new__} was called.
-// */
-// public static record ConstructorAndHandle(
-// Constructor<?> constructor, MethodHandle handle) {}
 
     /**
      * Return the table holding constructors and their method handles
@@ -438,5 +416,6 @@ public abstract class KernelType extends Representation
      * @param selfClass to seek
      * @return index in {@link #selfClasses()}
      */
+    @SuppressWarnings("static-method")
     public int getSubclassIndex(Class<?> selfClass) { return 0; }
 }

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/MROCalculator.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/MROCalculator.java
@@ -76,17 +76,18 @@ public class MROCalculator {
      * @param bases to analyse
      * @return the MRO as an array
      */
-    public static PyType[] getMRO(PyType type, PyType[] bases) {
+    // Compare CPython mro_implementation() in typeobject.c
+    public static BaseType[] getMRO(BaseType type, BaseType[] bases) {
         if (bases.length == 1) {
             // Fast path when there is a single base.
-            PyType base = bases[0];
+            BaseType base = bases[0];
             if (base.getBase() == null) {
                 // The one base is object
-                return new PyType[] {type, base};
+                return new BaseType[] {type, base};
             } else {
                 // The one base has an MRO of its own: prepend type.
-                PyType[] baseMRO = base.getMRO();
-                PyType[] mro = Util.prepend(type, baseMRO);
+                BaseType[] baseMRO = base.getMRO();
+                BaseType[] mro = Util.prepend(type, baseMRO);
                 return mro;
             }
         } else {
@@ -96,10 +97,11 @@ public class MROCalculator {
             if (mro == null) {
                 StringJoiner sj = new StringJoiner(",", "(", ")");
                 for (PyType b : bases) { sj.add(b.getName()); }
-                throw PyErr.format(PyExc.TypeError, NO_CONSISTENT_MRO, sj);
+                throw PyErr.format(PyExc.TypeError, NO_CONSISTENT_MRO,
+                        sj);
             }
             mro.add(0, type);
-            return mro.toArray(new PyType[mro.size()]);
+            return mro.toArray(new BaseType[mro.size()]);
         }
     }
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/PyObjectMethods.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/PyObjectMethods.java
@@ -98,8 +98,8 @@ final class PyObjectMethods {
     static Object __new__(PyType cls) {
         /*
          * We normally arrive here from PyType.__call__, where this/self
-         * is the the type we're asked to construct, and gets passed
-         * here as the 'cls' argument.
+         * is the the Python type of which we are asked to construct an
+         * instance, and gets passed here as the 'cls' argument.
          */
         if (cls == PyObject.TYPE) {
             return new Object();

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/ReplaceableType.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/ReplaceableType.java
@@ -8,12 +8,12 @@ import java.util.List;
  * A Python type object used where multiple Python types share a single
  * representation in Java, making them all acceptable for assignment to
  * the {@code __class__} member of Python instances of any of them. The
- * common representation encapsulates what Python terms the "layout
+ * common representation encapsulates what in Python terms the "layout
  * constraints". The Java implementation of Python instance methods in
  * such a type will have the common Java type (or a superclass) as their
  * {@code self} parameter.
  */
-public final class ReplaceableType extends BaseType {
+public non-sealed class ReplaceableType extends BaseType {
 
     /** The representation shared by this type and others. */
     final SharedRepresentation representation;

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/Representation.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/Representation.java
@@ -91,9 +91,7 @@ public abstract class Representation {
      *
      * @return the Python type object {@code type}
      */
-    static final SimpleType typeType() {
-        return factory.typeType();
-    }
+    static final SimpleType typeType() { return factory.typeType(); }
 
     /**
      * Get the Python type object {@code object} directly from the
@@ -128,8 +126,8 @@ public abstract class Representation {
      * The common type (class or interface) of Java classes representing
      * instances of the related Python {@code type}, and registered for
      * this {@code Representation}. If more than one Java class is
-     * registered to this representation, then in Java they must all
-     * inherit (extend or implement) the type recorded here.
+     * registered to this representation, then they must all inherit
+     * (extend or implement in Java) the type recorded here.
      * <p>
      * Classes representing instances of the related Python {@code type}
      * and <i>not</i> related by inheritance must be described in

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/Representation.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/Representation.java
@@ -38,7 +38,7 @@ import uk.co.farowl.vsj4.runtime.kernel.SpecialMethod.Signature;
  */
 public abstract class Representation {
 
-    /** Logger for representation/type object activity in the kernel. */
+    /** Logger for representation object activity in the kernel. */
     protected static final Logger logger =
             LoggerFactory.getLogger(Representation.class);
 
@@ -86,13 +86,23 @@ public abstract class Representation {
     }
 
     /**
-     * Get the Python type object {@code type}. Calls
-     * {@link TypeFactory#getTypeForType() factory.getTypeForType()}
+     * Get the Python type object {@code type} directly from the
+     * factory.
      *
      * @return the Python type object {@code type}
      */
-    static SimpleType getTypeForType() {
-        return factory.getTypeForType();
+    static final SimpleType typeType() {
+        return factory.typeType();
+    }
+
+    /**
+     * Get the Python type object {@code object} directly from the
+     * factory.
+     *
+     * @return the Python type object {@code object}
+     */
+    static final SimpleType objectType() {
+        return factory.objectType();
     }
 
     /*

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/Representation.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/Representation.java
@@ -85,6 +85,16 @@ public abstract class Representation {
         return registry.get(o.getClass());
     }
 
+    /**
+     * Get the Python type object {@code type}. Calls
+     * {@link TypeFactory#getTypeForType() factory.getTypeForType()}
+     *
+     * @return the Python type object {@code type}
+     */
+    static SimpleType getTypeForType() {
+        return factory.getTypeForType();
+    }
+
     /*
      * Give SpecialMethod access to private members (so it may write the
      * method handle caches), and to the runtime package in general. It
@@ -189,9 +199,9 @@ public abstract class Representation {
     }
 
     /**
-     * Fast check that an object of this type is exactly a Python
-     * {@code int}. We can do this without reference to the object
-     * itself, just from the representation.
+     * Fast check that an object having this as its Representation is
+     * exactly a Python {@code int}. We can do this without reference to
+     * the object itself, just from the representation.
      *
      * @implNote The result may be incorrect during type system
      *     bootstrap.
@@ -201,9 +211,9 @@ public abstract class Representation {
     public boolean isIntExact() { return this == PyLong.TYPE; }
 
     /**
-     * Fast check that an object of this type is exactly a Python
-     * {@code float}. We can do this without reference to the object
-     * itself, just from the representation.
+     * Fast check that an object having this as its Representation is
+     * exactly a Python {@code float}. We can do this without reference
+     * to the object itself, just from the representation.
      *
      * @implNote The result may be incorrect during type system
      *     bootstrap.

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/SimpleType.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/SimpleType.java
@@ -42,7 +42,8 @@ public non-sealed class SimpleType extends BaseType {
      * @param javaClass to which instances are assignable
      * @param bases of the type
      */
-    public SimpleType(String name, Class<?> javaClass, BaseType[] bases) {
+    public SimpleType(String name, Class<?> javaClass,
+            BaseType[] bases) {
         this(name, javaClass, javaClass, bases);
     }
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/SimpleType.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/SimpleType.java
@@ -13,7 +13,7 @@ import java.util.List;
  * must have a {@code self} parameter that accepts the representation
  * class (or a superclass).
  */
-public non-sealed class SimpleType extends BaseType {
+public final class SimpleType extends BaseType {
 
     /** To return as {@link #canonicalClass()}. */
     private final Class<?> canonicalClass;
@@ -65,7 +65,7 @@ public non-sealed class SimpleType extends BaseType {
      * @param object the type object for {@code object} (as base).
      */
     SimpleType(BaseType object) {
-        this("type", BaseType.class, SimpleType.class,
+        this("type", BaseType.class, ReplaceableType.class,
                 new BaseType[] {object});
     }
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/SpecialMethod.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/SpecialMethod.java
@@ -838,9 +838,8 @@ public enum SpecialMethod {
 
         } else {
             /*
-             * The retrieved dictionary is not a *method* descriptor,
-             * but it might still be a descriptor that we have to bind
-             * to self.
+             * The retrieved entry is not a *method* descriptor, but it
+             * might still be a descriptor that we have to bind to self.
              */
             try {
                 // Replace meth with result of descriptor binding.

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/SpecialMethod.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/SpecialMethod.java
@@ -1245,7 +1245,7 @@ public enum SpecialMethod {
          * @param access object providing access
          */
         public static void provideAccess(Required access) {
-            logger.atTrace().setMessage("Access provided to {}")
+            logger.atDebug().setMessage("Access provided to {}")
                     .addArgument(() -> access.getLookup().lookupClass()
                             .getName())
                     .log();
@@ -1502,7 +1502,7 @@ public enum SpecialMethod {
                 // Add to table
                 t.put(s.methodName, s);
                 // This is a good time to confirm initialisation
-                SMUtil.logger.atDebug()
+                SMUtil.logger.atTrace()
                         .setMessage("{} with signature {}{}")
                         .addArgument(s.methodName)
                         .addArgument(s.generic.type())

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/SpecialMethod.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/SpecialMethod.java
@@ -20,7 +20,6 @@ import org.slf4j.LoggerFactory;
 import uk.co.farowl.vsj4.runtime.Abstract;
 import uk.co.farowl.vsj4.runtime.Callables;
 import uk.co.farowl.vsj4.runtime.ClassShorthand;
-import uk.co.farowl.vsj4.runtime.FastCall;
 import uk.co.farowl.vsj4.runtime.PyBaseException;
 import uk.co.farowl.vsj4.runtime.PyErr;
 import uk.co.farowl.vsj4.runtime.PyExc;
@@ -682,8 +681,8 @@ public enum SpecialMethod {
      * Each of the methods called {@code slot(self, ...)} looks up this
      * special method by name in the type of its {@code self} argument,
      * and calls it with the given arguments. A handle on the variant
-     * matching {@link #signature}, and bound to this special method, is
-     * placed in the {@link #generic} member during construction.
+     * matching {@link #signature}, and bound to this method, is placed
+     * in the {@link #generic} member during construction.
      * <p>
      * We in-line a specialised variant of attribute access in which we
      * avoid, if we can, binding a method object to {@code self}.
@@ -697,10 +696,14 @@ public enum SpecialMethod {
      * available. We use them in a similar way when a special method is
      * overridden in Python. (See private methods in {@link BaseType}.)
      * Ours are simpler than CPython's because we signal an empty slot
-     * by a lightweight {@link EmptyException}, rather than by
-     * {@code null}. We therefore do not need to reproduce the logic in
-     * the Abstract API, where the presence of a slot function fools it
-     * into thinking the special method is defined.
+     * by a lightweight {@link EmptyException}, rather than by returning
+     * {@code null}.
+     * <p>
+     * In CPython, when the Abstract API method has a choice to make,
+     * e.g. between {@code __add__} and {@code __radd__}, it inspects
+     * the type slot, but the presence of a slot function makes it look
+     * like the special method is defined even when it isn't. The slot
+     * function itself then has to replicate the logic.
      *
      * @param self first operand.
      * @param args other operands.
@@ -709,47 +712,36 @@ public enum SpecialMethod {
      * @throws PyBaseException from the call
      * @throws Throwable from the call
      */
-    // Compare CPython slot_* in typeobject.c
+    // Compare CPython slot_tp_call in typeobject.c
+    // See also lookup_method etc. in typeobject.c
     Object slot(Object self, Object[] args, String[] kwds)
             throws Throwable {
 
         PyType type = PyType.of(self);
         Object meth = type.lookup(methodName);
         if (meth == null) { throw SMUtil.EMPTY; }
-        // TODO inline equivalent code to other slot() functions
-        // return callAsMethod(type, meth, self, args, kwds);
 
         // What kind of object did we find? (Could be anything.)
-        Representation methRep = Representation.get(meth);
-        assert methRep != null;
+        Representation rep = Representation.get(meth);
+        PyType methType = rep.pythonType(meth);
 
-        if (methRep.pythonType(meth).isMethodDescr()) {
+        if (methType.isMethodDescr()) {
             /*
              * meth is a method descriptor. Avoid construction of a
-             * bound method, supplying self as the first argument in a
-             * new argument array. Keywords remain valid as they align
-             * to the end.
+             * bound method and supplying self separately to avoid
+             * creating a new argument array, if possible. Keywords
+             * remain valid as they align to the end.
              */
-            if (meth instanceof FastCall fast) {
-                return fast.call(self, args, kwds);
-            } else {
-                return _PyUtil.callPrepend(meth, self, args, kwds);
-            }
+            return _PyUtil.callPrepend(meth, self, args, kwds);
         } else {
             /*
              * The retrieved dictionary is not a *method* descriptor,
              * but it might still be a descriptor that we have to bind
              * to self.
              */
-            try {
+            if (methType.isDescr()) {
                 // Replace meth with result of descriptor binding.
-                // FIXME: undecided how exactly to call __get__ here
-                // meth = methRep.op_get().invokeExact(meth, self,
-                // type);
-                meth = op_get.handle(methRep).invokeExact(meth, self,
-                        type);
-            } catch (EmptyException e) {
-                // Not a descriptor at all.
+                meth = op_get.handle(rep).invokeExact(meth, self, type);
             }
             /*
              * meth is now the thing to call. We do not pass self here,
@@ -762,101 +754,158 @@ public enum SpecialMethod {
         }
     }
 
+    /**
+     * Looks up this special method by name in the type of {@code self},
+     * and call it with argument {@code (self)}. A handle matching
+     * {@link #signature}, and bound to this method, is placed in the
+     * {@link #generic} member during construction.
+     * <p>
+     * We avoid, if we can, binding a method object to {@code self}.
+     * Instead, we call the unbound method with the {@code self}
+     * argument placed first.
+     *
+     * @param self first operand.
+     * @return result of the call
+     * @throws Throwable from the call
+     */
+    // Compare CPython SLOT0 macro in typeobject.c
+    // See also vectorcall_method etc. in typeobject.c
     Object slot(Object self) throws Throwable {
         PyType type = PyType.of(self);
         Object meth = type.lookup(methodName);
         if (meth == null) { throw SMUtil.EMPTY; }
-        return callAsMethod(type, meth, self);
-    }
-
-    Object slot(Object self, Object w) throws Throwable {
-        PyType type = PyType.of(self);
-        Object meth = type.lookup(methodName);
-        if (meth == null) { throw SMUtil.EMPTY; }
-        return callAsMethod(type, meth, self, w);
-    }
-
-    Object slot(Object self, Object w, Object m) throws Throwable {
-        PyType type = PyType.of(self);
-        Object meth = type.lookup(methodName);
-        if (meth == null) { throw SMUtil.EMPTY; }
-        return callAsMethod(type, meth, self, w, m);
-    }
-
-    Object slot(Object self, Object obj, PyType t) throws Throwable {
-        PyType type = PyType.of(self);
-        Object meth = type.lookup(methodName);
-        if (meth == null) { throw SMUtil.EMPTY; }
-        return callAsMethod(type, meth, self, obj, t);
-    }
-
-    // TODO Do not need callAsMethod after inlining.
-    private static Object callAsMethod(PyType type, Object meth,
-            Object self, Object... args) throws Throwable {
-        return callAsMethod(type, meth, self, args, null);
-    }
-
-    /**
-     * Call the object we found by lookup on the type of {@code self},
-     * as part of invoking a one of the definitions of
-     * {@link #slot(Object, Object[], String[]) slot(...)}. These are
-     * the slot functions that fill the cache for a special method when
-     * we cannot find a more direct answer (see
-     * {@link SpecialMethod#generic}.
-     *
-     * @param type of {@code self}.
-     * @param meth looked up on {@code type} may be a descriptor.
-     * @param self first operand.
-     * @param args other operands.
-     * @param kwds naming the last {@code args} or {@code null}.
-     * @return result of the call
-     * @throws PyBaseException from the call
-     * @throws Throwable from the call
-     */
-    // Compare CPython vectorcall_unbound in typeobject.c
-    /*
-     * Also lookup_method and lookup_maybe_method. Actually, none of
-     * these is an equivalent. We do roughly the same work as CPython in
-     * our slot* functions, just in a different arrangement, avoiding
-     * the &unbound argument, which is awkward in Java..
-     */
-    private static Object callAsMethod(PyType type, Object meth,
-            Object self, Object[] args, String[] kwds)
-            throws PyBaseException, Throwable {
         // What kind of object did we find? (Could be anything.)
         Representation rep = Representation.get(meth);
         PyType methType = rep.pythonType(meth);
 
         if (methType.isMethodDescr()) {
-            /*
-             * meth is a method descriptor. Avoid construction of a
-             * bound method, supplying self as the first argument in a
-             * new argument array. Keywords remain valid as they align
-             * to the end.
-             */
-            return _PyUtil.callPrepend(meth, self, args, kwds);
-
+            return Callables.call(meth, self);
         } else {
-            /*
-             * The retrieved entry is not a *method* descriptor, but it
-             * might still be a descriptor that we have to bind to self.
-             */
-            try {
+            // We might still have have to bind meth to self.
+            if (methType.isDescr()) {
                 // Replace meth with result of descriptor binding.
-                // FIXME: undecided how exactly to call __get__ here
-                // meth = rep.op_get().invokeExact(meth, self, type);
                 meth = op_get.handle(rep).invokeExact(meth, self, type);
-            } catch (EmptyException e) {
-                // Not a descriptor at all.
             }
-            /*
-             * meth is now the thing to call. We do not pass self here,
-             * as meth has either bound self, or decided to ignore it
-             * (e.g. @staticmethod). It ought to be an instance of a
-             * class defining __call__. Or it may be something we can't
-             * actually call, in which case we'll find out next.
-             */
-            return Callables.call(meth, args, kwds);
+            // meth is now the thing to call.
+            return Callables.call(meth);
+        }
+    }
+
+    /**
+     * Looks up this special method by name in the type of {@code self},
+     * and call it with argument {@code (self, w)}. A handle matching
+     * {@link #signature}, and bound to this method, is placed in the
+     * {@link #generic} member during construction.
+     * <p>
+     * We avoid, if we can, binding a method object to {@code self}.
+     * Instead, we call the unbound method with the {@code self}
+     * argument placed first.
+     *
+     * @param self first operand.
+     * @param w second operand.
+     * @return result of the call
+     * @throws Throwable from the call
+     */
+    // Compare CPython SLOT1 macro in typeobject.c
+    // See also vectorcall_method etc. in typeobject.c
+    Object slot(Object self, Object w) throws Throwable {
+        PyType type = PyType.of(self);
+        Object meth = type.lookup(methodName);
+        if (meth == null) { throw SMUtil.EMPTY; }
+        // What kind of object did we find? (Could be anything.)
+        Representation rep = Representation.get(meth);
+        PyType methType = rep.pythonType(meth);
+
+        if (methType.isMethodDescr()) {
+            return Callables.call(meth, self, w);
+        } else {
+            // We might still have have to bind meth to self.
+            if (methType.isDescr()) {
+                // Replace meth with result of descriptor binding.
+                meth = op_get.handle(rep).invokeExact(meth, self, type);
+            }
+            // meth is now the thing to call.
+            return Callables.call(meth, w);
+        }
+    }
+
+    /**
+     * Looks up this special method by name in the type of {@code self},
+     * and call it with argument {@code (self, w, m)}. A handle matching
+     * {@link #signature}, and bound to this method, is placed in the
+     * {@link #generic} member during construction.
+     * <p>
+     * We avoid, if we can, binding a method object to {@code self}.
+     * Instead, we call the unbound method with the {@code self}
+     * argument placed first.
+     *
+     * @param self first operand.
+     * @param w second operand.
+     * @param m third operand.
+     * @return result of the call
+     * @throws Throwable from the call
+     */
+    // Compare CPython slot_tp_descr_set in typeobject.c
+    // See also vectorcall_method etc. in typeobject.c
+    Object slot(Object self, Object w, Object m) throws Throwable {
+        PyType type = PyType.of(self);
+        Object meth = type.lookup(methodName);
+        if (meth == null) { throw SMUtil.EMPTY; }
+        // What kind of object did we find? (Could be anything.)
+        Representation rep = Representation.get(meth);
+        PyType methType = rep.pythonType(meth);
+
+        if (methType.isMethodDescr()) {
+            return Callables.call(meth, self, w, m);
+        } else {
+            // We might still have have to bind meth to self.
+            if (methType.isDescr()) {
+                // Replace meth with result of descriptor binding.
+                meth = op_get.handle(rep).invokeExact(meth, self, type);
+            }
+            // meth is now the thing to call.
+            return Callables.call(meth, w, m);
+        }
+    }
+
+    /**
+     * Looks up this special method by name in the type of {@code self},
+     * and call it with argument {@code (self, obj, t)}. The signature
+     * differs from {@link #slot(Object, Object, Object)} in requiring a
+     * type in the third position, so that we may match the
+     * {@link #signature} when a handle bound to this method, is placed
+     * in the {@link #generic} member during construction.
+     * <p>
+     * We avoid, if we can, binding a method object to {@code self}.
+     * Instead, we call the unbound method with the {@code self}
+     * argument placed first.
+     *
+     * @param self first operand.
+     * @param obj second operand.
+     * @param t third operand.
+     * @return result of the call
+     * @throws Throwable from the call
+     */
+    // Compare CPython slot_tp_descr_get in typeobject.c
+    // See also vectorcall_method etc. in typeobject.c
+    Object slot(Object self, Object obj, PyType t) throws Throwable {
+        PyType type = PyType.of(self);
+        Object meth = type.lookup(methodName);
+        if (meth == null) { throw SMUtil.EMPTY; }
+        // What kind of object did we find? (Could be anything.)
+        Representation rep = Representation.get(meth);
+        PyType methType = rep.pythonType(meth);
+
+        if (methType.isMethodDescr()) {
+            return Callables.call(meth, self, obj, t);
+        } else {
+            // We might still have have to bind meth to self.
+            if (methType.isDescr()) {
+                // Replace meth with result of descriptor binding.
+                meth = op_get.handle(rep).invokeExact(meth, self, type);
+            }
+            // meth is now the thing to call.
+            return Callables.call(meth, obj, t);
         }
     }
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/TypeExposer.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/TypeExposer.java
@@ -35,7 +35,7 @@ public interface TypeExposer {
     void exposeMembers(Class<?> memberClass);
 
     /**
-     * A name-value pair that hold one entry intended for the dictionary
+     * A name-value pair that holds one entry intended for the dictionary
      * of the type.
      */
     public static record Entry(String name, Object value) {}

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/TypeFactory.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/TypeFactory.java
@@ -243,8 +243,8 @@ public class TypeFactory {
 
     /**
      * Inner class to the factory that implements the registry
-     * interface. This allows the registry to have behaviour that access
-     * the factory that contains it.
+     * interface. This allows the registry to have behaviour that relies
+     * upon access to the factory that contains it.
      */
     private class Registry extends TypeRegistry {
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/TypeFactory.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/TypeFactory.java
@@ -911,6 +911,9 @@ public class TypeFactory {
 
                 // Derive remaining feature flags
                 type.deriveFeatures(spec);
+
+                // Say we're done
+                type.kernelFeatures.add(KernelTypeFlag.READY);
             }
 
             /**

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/TypeFactory.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/TypeFactory.java
@@ -206,7 +206,7 @@ public class TypeFactory {
                 new PrimordialTypeSpec(objectType, kernelLU)
                         .methodImpls(PyObjectMethods.class);
         TypeSpec specOfType = new PrimordialTypeSpec(typeType, kernelLU)
-                .canonicalBase(typeType.canonicalClass());
+                .canonicalClass(typeType.canonicalClass());
 
         // An error during bootstrap says we were creating 'object'
         lastContext = specOfObject;
@@ -779,7 +779,7 @@ public class TypeFactory {
 
             // It has these (potentially > 1) representations:
             Class<?> primary = spec.getPrimary();
-            Class<?> canonical = spec.getCanonicalBase();
+            Class<?> canonical = spec.getCanonicalClass();
             List<Class<?>> adopted = spec.getAdopted();
             List<Class<?>> accepted = spec.getAccepted();
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/TypeFactory.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/TypeFactory.java
@@ -996,6 +996,9 @@ public class TypeFactory {
                 type.inheritFeatures();
                 type.addFeatures(spec);
 
+                // TODO Avoid the exposer when type defined in Python.
+                // In practice, when type.__new__ wrote the spec.
+
                 // Construct an exposer for the type.
                 TypeExposer exposer = gatherJavaAttributes();
 

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/TypeFactory.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/TypeFactory.java
@@ -1214,7 +1214,7 @@ public class TypeFactory {
             // I think the primordial types are only simple
             assert type instanceof SimpleType;
             this.primary(type.javaClass()).bases(type.getBases())
-                    .add(Feature.IMMUTABLE);
+                    .add(Feature.IMMUTABLE, Feature.BASETYPE);
         }
     }
 }

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/TypeFactory.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/TypeFactory.java
@@ -143,9 +143,9 @@ public class TypeFactory {
     /**
      * Construct the {@code type} object {@code type}, and necessarily
      * therefore, the one for {@code object} which is its base. The type
-     * factory holds these internally, but does not publish them in the
-     * registry until {@link #createBootstrapTypes(Lookup, Function)} is
-     * called.
+     * factory holds these internally, but does not complete or publish
+     * them in the registry until
+     * {@link #publishBootstrapTypes(Function)} is called.
      *
      * @return the type object for {@code type}
      *
@@ -187,7 +187,7 @@ public class TypeFactory {
                 new PrimordialTypeSpec(objectType, kernelLU)
                         .methodImpls(PyObjectMethods.class);
         TypeSpec specOfType = new PrimordialTypeSpec(typeType, kernelLU)
-                .canonicalBase(SimpleType.class);
+                .canonicalBase(typeType.canonicalClass());
 
         // An error during bootstrap says we were creating 'object'
         lastContext = specOfObject;
@@ -534,7 +534,7 @@ public class TypeFactory {
      * Whenever some thread completes a lookup in the registry, the
      * {@code Representation} it finds get cached outside the protection
      * of the {@code TypeFactory} lock. It will be visible to all
-     * threads. However, thread other than this one can proceed with
+     * threads. However, no thread other than this one can proceed with
      * such lookup until this method returns (releasing the factory
      * lock), and the initialisation of the {@code TypeSystem} class
      * completes (releasing that lock).

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/TypeRegistry.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/kernel/TypeRegistry.java
@@ -13,12 +13,13 @@ import uk.co.farowl.vsj4.support.InterpreterError;
  * Mapping from Java class to the {@link Representation} that provides
  * instances of the class with Python semantics. We refer to this as a
  * "type registry" because the {@code Representation} retrieved contains
- * some type information and leads directly to more.
+ * some type information and leads directly to more. Also
+ * "representation registry" is just too much of a tongue twister.
  * <p>
  * In normal operation (outside test cases) there is only one instance
- * of this class, owned by a {@link TypeFactory}, in turn created by
- * {@link PyType}. Note that only the owning factory has a write
- * interface to the registry.
+ * of this class, owned by a {@link TypeFactory}, in turn created by the
+ * type system. Note that only the owning factory has a write interface
+ * to the registry.
  */
 public abstract class TypeRegistry extends ClassValue<Representation> {
 
@@ -40,22 +41,23 @@ public abstract class TypeRegistry extends ClassValue<Representation> {
             new WeakHashMap<>();
 
     /**
-     * Find a {@code Representation} for the given class. There are five
-     * broad cases. {@code c} might be:
+     * Find a {@code Representation} to describe the given class in
+     * relation to the Python type system. There are these broad cases.
+     * {@code c} might be:
      * <ol>
-     * <li>the crafted canonical implementation of a Python type</li>
+     * <li>a crafted implementation of a Python type</li>
      * <li>an adopted implementation of some Python type</li>
-     * <li>the implementation of the base of Python sub-classes of a
-     * Python type</li>
+     * <li>the Java representation class of multiple Python classes of
+     * mutually replaceable {@code __class__}</li>
      * <li>a found Java type</li>
      * <li>the crafted base of Python sub-classes of a found Java
      * type</li>
      * </ol>
      * Cases 1, 3 and 5 may be recognised by marker interfaces on
      * {@code c}. Case 2 may only be distinguished from case 4 only
-     * because classes that are adopted implementations will have been
-     * posted to {@link #map} before the first call, when their
-     * {@link PyType}s were created.
+     * because classes that are adopted representations will have been
+     * registered as such, when their type was defined, before the
+     * question is first posed.
      */
     @Override
     protected Representation computeValue(Class<?> c) {

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/subclass/SubclassFactory.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/subclass/SubclassFactory.java
@@ -271,7 +271,6 @@ public class SubclassFactory {
          */
         final boolean manageDictAssignment;
 
-
         // private final MethodNode staticInit;
 
         /**
@@ -418,18 +417,18 @@ public class SubclassFactory {
             String descr;
             if (manageClassAssignment) {
                 /*
-                 * When the base does not hold the actual type of the
-                 * object, this constructor constructors have the actual
-                 * PyType as their first parameter.
+                 * The base does not hold the actual type of the object.
+                 * Its constructor does not have the actual PyType as
+                 * its first parameter, but ours must.
                  */
                 Type[] params = Util.prepend(PY_TYPE_TYPE, baseParams);
                 descr = Type.getMethodType(Type.VOID_TYPE, params)
                         .getDescriptor();
             } else {
                 /*
-                 * When the base holds the actual type of the object,
-                 * its constructor does not have a PyType parameter,
-                 * while the synthesised constructor must.
+                 * The base holds the actual type of the object. Its
+                 * constructor has a PyType parameter, and so must the
+                 * synthesised constructor.
                  */
                 assert baseParams.length > 0;
                 assert PY_TYPE_TYPE.equals(baseParams[0]);

--- a/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/subclass/SubclassSpec.java
+++ b/rt4core/src/main/java/uk/co/farowl/vsj4/runtime/subclass/SubclassSpec.java
@@ -123,6 +123,13 @@ public class SubclassSpec extends NamedSpec implements Cloneable {
             }
 
             // FIXME : (maybe order and) freeze interfaces.
+            /*
+             * Order of interfaces is *not* significant in Java and
+             * treating them as ordered in the MRO is perhaps behind
+             * certain problems in Jython 2 such as #70 and #391. Yet we
+             * must (I think) acknowledge them when looking for a
+             * representation, and probably as bases in Python.
+             */
 
             /*
              * The specification calls for instances to have a __dict__

--- a/rt4core/src/test/java/uk/co/farowl/vsj4/runtime/AbstractCallablesAPITest.java
+++ b/rt4core/src/test/java/uk/co/farowl/vsj4/runtime/AbstractCallablesAPITest.java
@@ -1,0 +1,256 @@
+// Copyright (c)2025 Jython Developers.
+// Licensed to PSF under a contributor agreement.
+package uk.co.farowl.vsj4.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test the {@link Callables} API class on a variety of types. We are
+ * looking for correct behaviour in the cases attempted but mostly
+ * testing the invocation of special method {@code __call__}.
+ * <p>
+ * Built-in descriptor types have extensive tests elsewhere in which we
+ * call them in a variety of ways. Those objects implement the
+ * {@link FastCall} interface. Here we test that callable objects not
+ * implementing that interface are correctly called.
+ */
+@DisplayName("When called through the Abstract API ...")
+class AbstractCallablesAPITest extends UnitTestSupport {
+
+    /**
+     * This abstract base forms a check-list of methods we mean to test.
+     */
+    abstract static class CallTests {
+
+        final Object obj;
+        static final Object[] a = {0, 1, 2, 3, 4, 5, 6, 7};
+
+        /**
+         * Construct test from callable object.
+         *
+         * @param obj the callable object
+         */
+        CallTests(Object obj) { this.obj = obj; }
+
+        /**
+         * A holder for the unpacked result of the call, which is always
+         * a pair of a {@code tuple} and a {@code dict}.
+         */
+        record ArgsKwargs(Object[] pos, Map<Object, Object> kwargs) {}
+
+        /**
+         * Unpack a result to an {@link ArgsKwargs}.
+         *
+         * @param result a pair of a {@code tuple} and a {@code dict}
+         * @return holding result as an array and a {@link Map}.
+         */
+        static ArgsKwargs unpack(Object result) {
+            PyTuple r = (PyTuple)result, pos = (PyTuple)r.get(0);
+            PyDict kwargs = (PyDict)r.get(1);
+            return new ArgsKwargs(pos.toArray(), kwargs);
+        }
+
+        /**
+         * Check the result of a call against expectations and the
+         * contents of {@link #a}.
+         *
+         * @param result to check
+         * @param np the number of positional parameters
+         * @param names the names of keyword parameters (in order)
+         */
+        static void check(Object result, int np, String... names) {
+            ArgsKwargs r = unpack(result);
+            // The positional arguments must match a[:np]
+            Object[] p = r.pos();
+            assertEquals(p.length, np);
+            for (int i = 0; i < np; i++) { assertEquals(a[i], p[i]); }
+            // The arguments given by keyword must match a[np:np+nk]
+            int nk = names == null ? 0 : names.length, k = np;
+            Map<Object, Object> kwargs = r.kwargs();
+            assertEquals(kwargs.size(), nk);
+            for (String key : names) {
+                assertPythonEquals(kwargs.get(key), a[k++]);
+            }
+        }
+
+        /**
+         * Call with no arguments.
+         *
+         * @throws Throwable unexpectedly.
+         */
+        @Test
+        @DisplayName("obj.call()")
+        void check_0p() throws Throwable {
+            Object result = Callables.call(obj);
+            check(result, 0);
+        }
+
+        /**
+         * Call with 1 positional argument.
+         *
+         * @throws Throwable unexpectedly.
+         */
+        @Test
+        @DisplayName("obj.call(a0)")
+        void check_1p() throws Throwable {
+            Object result = Callables.call(obj, a[0]);
+            check(result, 1);
+        }
+
+        /**
+         * Call with 2 positional arguments.
+         *
+         * @throws Throwable unexpectedly.
+         */
+        @Test
+        @DisplayName("obj.call(a0, a1)")
+        void check_2p() throws Throwable {
+            Object result = Callables.call(obj, a[0], a[1]);
+            check(result, 2);
+        }
+
+        /**
+         * Call with 3 positional arguments.
+         *
+         * @throws Throwable unexpectedly.
+         */
+        @Test
+        @DisplayName("obj.call(a0, a1, a2)")
+        void check_3p() throws Throwable {
+            Object result = Callables.call(obj, a[0], a[1], a[2]);
+            check(result, 3);
+        }
+
+        /**
+         * Call with 4 positional arguments.
+         *
+         * @throws Throwable unexpectedly.
+         */
+        @Test
+        @DisplayName("obj.call(a0, a1, a2, a3)")
+        void check_4p() throws Throwable {
+            Object result = Callables.call(obj, a[0], a[1], a[2], a[3]);
+            check(result, 4);
+        }
+
+        /**
+         * Call with 5 positional arguments.
+         *
+         * @throws Throwable unexpectedly.
+         */
+        @Test
+        @DisplayName("obj.call(a0, a1, a2, a3, a4)")
+        void check_5p() throws Throwable {
+            Object result =
+                    Callables.call(obj, a[0], a[1], a[2], a[3], a[4]);
+            check(result, 5);
+        }
+
+        /**
+         * Call with only keyword arguments.
+         *
+         * @throws Throwable unexpectedly.
+         */
+        @Test
+        @DisplayName("obj.call(x=a0, y=a1)")
+        void check_0p2k() throws Throwable {
+            Object[] args = {a[0], a[1]};
+            String[] names = {"x", "y"};
+            Object result = Callables.call(obj, args, names);
+            check(result, 0, names);
+        }
+
+        /**
+         * Call with 1 positional argument and 3 keyword arguments.
+         *
+         * @throws Throwable unexpectedly.
+         */
+        @Test
+        @DisplayName("obj.call(a0, x=a1, y=a2, z=a3)")
+        void check_1p3k() throws Throwable {
+            Object[] args = Arrays.copyOf(a, 4);
+            String[] names = {"x", "y", "z"};
+            Object result = Callables.call(obj, args, names);
+            check(result, 1, names);
+        }
+
+        /**
+         * Call with 3 positional argument and 3 keyword arguments.
+         *
+         * @throws Throwable unexpectedly.
+         */
+        @Test
+        @DisplayName("obj.call(a0, a1, a2, x=a3, y=a4, z=a5)")
+        void check_3p3k() throws Throwable {
+            Object[] args = Arrays.copyOf(a, 6);
+            String[] names = {"x", "y", "z"};
+            Object result = Callables.call(obj, args, names);
+            check(result, 3, names);
+        }
+    }
+
+    /**
+     * Call a Python type implementing {@code __call__} in Java via the
+     * {@link Callables} API.
+     */
+    @Nested
+    @DisplayName("an object defining '__call__' implements ...")
+    class SlowCallableTest extends CallTests {
+        SlowCallableTest() { super(new SlowCallable()); }
+    }
+
+    /**
+     * Call a Python type implementing {@link FastCall} via the
+     * {@link Callables} API. Technically it implements
+     * {@code FastCall}, but really it just delegates to
+     * {@link SlowCallable}.
+     */
+    @Nested
+    @DisplayName("an object with the FastCall interface implements ...")
+    class FastCallSlowTest extends CallTests {
+        FastCallSlowTest() {
+            super(new FastCall.Slow(new SlowCallable()));
+        }
+    }
+
+    /**
+     * A Python type implemented in Java that defines __call__, but
+     * doesn't implement FastCall.
+     */
+    static class SlowCallable {
+        static PyType TYPE = PyType.fromSpec(
+                new TypeSpec("SlowCallable", MethodHandles.lookup()));
+
+        /**
+         * {@code __class__} simply plays back its arguments, positional
+         * ({@code pos}) and keyword ({@code kwargs}).
+         *
+         * @param args all arguments
+         * @param names keywords matching trailing args
+         * @return Python {@code (pos:tuple, kwargs:dict))}
+         */
+        @SuppressWarnings("static-method")
+        Object __call__(Object[] args, String[] names) {
+            int k = names == null ? 0 : names.length;
+            int n = args.length - k;
+            // Make a tuple of the positional arguments
+            PyTuple pos = new PyTuple(args, 0, n);
+
+            // Load a dictionary from the keyword arguments
+            PyDict kwargs = Py.dict();
+            for (int i = 0, j = n; i < k; i++, j++) {
+                kwargs.put(names[i], args[j]);
+            }
+            // Return the two as a pair
+            return Py.tuple(pos, kwargs);
+        }
+    }
+}

--- a/rt4core/src/test/java/uk/co/farowl/vsj4/runtime/TypeConcurrencyTest.java
+++ b/rt4core/src/test/java/uk/co/farowl/vsj4/runtime/TypeConcurrencyTest.java
@@ -60,7 +60,7 @@ class TypeConcurrencyTest {
             LoggerFactory.getLogger(TypeConcurrencyTest.class);
 
     /** Threads in total. &gt;&gt; {@code setUpClass().NCASES} */
-    static final int NTHREADS = 10;
+    static final int NTHREADS = 20;
 
     /** If defined, dump the times recorded by threads. */
     static final String DUMP_PROPERTY =
@@ -70,8 +70,8 @@ class TypeConcurrencyTest {
      * Check this many threads actually concurrent. Ideally
      * &gt;{@code setUpClass().NCASES} but expectation depends on CPU.
      */
-    static int MIN_THREADS =
-            Math.min(Runtime.getRuntime().availableProcessors(), 10);
+    static int MIN_THREADS = Math.min(
+            Runtime.getRuntime().availableProcessors(), NTHREADS / 2);
 
     /** Random (or deterministic) order. */
     // static final long seed = System.currentTimeMillis();
@@ -179,7 +179,8 @@ class TypeConcurrencyTest {
         }
 
         // Dump the thread times by start time.
-        if (truthy(DUMP_PROPERTY)) { dumpThreads(); }
+        // if (truthy(DUMP_PROPERTY)) { dumpThreads(); }
+        dumpThreads();
     }
 
     /** Property is defined and nothing like "false". */
@@ -225,7 +226,9 @@ class TypeConcurrencyTest {
         // Enough relative start times should be negative
         long competitors = threads.stream()
                 .filter(t -> t.startNanoTime <= 0L).count();
-        logger.info("{} threads were racing.", competitors);
+        logger.info(
+                "{} threads were racing. (Min {} on this platform.)",
+                competitors, MIN_THREADS);
         assertFalse(competitors < MIN_THREADS, () -> String
                 .format("Detect < %d competitors.", MIN_THREADS));
     }

--- a/rt4core/src/test/java/uk/co/farowl/vsj4/runtime/TypeConcurrencyTest.java
+++ b/rt4core/src/test/java/uk/co/farowl/vsj4/runtime/TypeConcurrencyTest.java
@@ -74,8 +74,8 @@ class TypeConcurrencyTest {
             Runtime.getRuntime().availableProcessors(), NTHREADS / 2);
 
     /** Random (or deterministic) order. */
-    // static final long seed = System.currentTimeMillis();
-    static final long seed = 1234L; // Somewhat repeatable
+    static final long seed = System.currentTimeMillis();
+    // static final long seed = 12345L; // Somewhat repeatable
 
     /** Threads to run. */
     static final List<AccessThread> threads = new ArrayList<>();
@@ -263,7 +263,7 @@ class TypeConcurrencyTest {
      */
     @SuppressWarnings("static-method")
     @Test
-    @DisplayName("__repr__ seen if present")
+    @DisplayName("__repr__ is seen")
     void checkRepr() throws PyAttributeError, Throwable {
         for (AccessThread at : threads) {
             PyType t = at.type;
@@ -272,7 +272,7 @@ class TypeConcurrencyTest {
              * lookup (see otherActions()) before t was Python ready.
              */
             assertSame(t.lookup("__repr__"), at.reprMethod,
-                    "check '__repr__' was seen");
+                    () -> "check '__repr__' in " + t.getName());
         }
     }
 
@@ -285,7 +285,7 @@ class TypeConcurrencyTest {
      */
     @SuppressWarnings("static-method")
     @Test
-    @DisplayName("__call__ seen if present")
+    @DisplayName("__call__ is seen")
     void checkCall() throws PyAttributeError, Throwable {
         for (AccessThread at : threads) {
             PyType t = at.type;
@@ -294,7 +294,7 @@ class TypeConcurrencyTest {
              * lookup (see otherActions()) before t was Python ready.
              */
             assertSame(t.lookup("__call__"), at.callMethod,
-                    "check '__call__' was seen");
+                    () -> "check '__call__' in " + t.getName());
         }
     }
 
@@ -316,9 +316,9 @@ class TypeConcurrencyTest {
              * lookup (see otherActions()) before t was Python ready.
              */
             assertSame(t.lookup("foo"), at.fooMethod,
-                    "check 'foo' was seen");
+                    () -> "check 'foo' in " + t.getName());
             assertSame(t.lookup("bar"), at.barMethod,
-                    "check 'bar' was seen");
+                    () -> "check 'bar' in " + t.getName());
         }
     }
 
@@ -424,7 +424,10 @@ class TypeConcurrencyTest {
             BaseType t = (BaseType)type;
             ready = t.hasFeature(KernelTypeFlag.READY);
             features = t.getFeatures();
+            reprMethod = t.lookup("__repr__");
+            callMethod = t.lookup("__call__");
             fooMethod = t.lookup("foo");
+            barMethod = t.lookup("bar");
         }
 
         /**

--- a/rt4core/src/test/java/uk/co/farowl/vsj4/runtime/TypeConcurrencyTest.java
+++ b/rt4core/src/test/java/uk/co/farowl/vsj4/runtime/TypeConcurrencyTest.java
@@ -1,0 +1,472 @@
+// Copyright (c)2025 Jython Developers.
+// Licensed to PSF under a contributor agreement.
+package uk.co.farowl.vsj4.runtime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Random;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import uk.co.farowl.vsj4.runtime.Exposed.PythonMethod;
+import uk.co.farowl.vsj4.runtime.kernel.BaseType;
+import uk.co.farowl.vsj4.runtime.kernel.KernelTypeFlag;
+
+/**
+ * This is a variant of {@link BootstrapTest} focusing on competition to
+ * create and use non-bootstrap types in Java. We test that when threads
+ * create (and therefore publish) types they are either Python-ready
+ * from the start or properly protected by locks that block attribute
+ * access.
+ * <p>
+ * We shall start a lot of threads, as close to simultaneously as we can
+ * manage, that each access a type that the type system will not have
+ * been seen before.
+ * <p>
+ * We have each thread make observation and attempt operations on the
+ * type that should be consistent with that type's final state. The
+ * thread race occurs during {@link #setUpClass()}. Tests (JUnit tests)
+ * run after the threads become joined, and take arbitrarily long, so
+ * they have to operate on observations made "hot" during the race.
+ * <p>
+ * Each thread records when it started and when it got its answer. For a
+ * satisfactory test, multiple threads should be racing before the first
+ * thread completes its first action so we have a genuine race. (This is
+ * less likely on hosts with few CPUs.)
+ */
+@DisplayName("When multiple threads publish type objects")
+@TestMethodOrder(MethodOrderer.MethodName.class)
+class TypeConcurrencyTest {
+
+    /** Logger for the test. */
+    static final Logger logger =
+            LoggerFactory.getLogger(TypeConcurrencyTest.class);
+
+    /** Threads in total. &gt;&gt; {@code setUpClass().NCASES} */
+    static final int NTHREADS = 10;
+
+    /** If defined, dump the times recorded by threads. */
+    static final String DUMP_PROPERTY =
+            "uk.co.farowl.vsj4.runtime.TypeConcurrencyTest.times";
+
+    /**
+     * Check this many threads actually concurrent. Ideally
+     * &gt;{@code setUpClass().NCASES} but expectation depends on CPU.
+     */
+    static int MIN_THREADS =
+            Math.min(Runtime.getRuntime().availableProcessors(), 10);
+
+    /** Random (or deterministic) order. */
+    // static final long seed = System.currentTimeMillis();
+    static final long seed = 1234L; // Somewhat repeatable
+
+    /** Threads to run. */
+    static final List<AccessThread> threads = new ArrayList<>();
+    /** A barrier they all wait behind. */
+    static CyclicBarrier barrier;
+    /** Source of random behaviour. */
+    static Random random = new Random(seed);
+
+    /** Time the first thread completed its first action. */
+    static long referenceNanoTime;
+
+    /**
+     * We create multiple threads for each behavioural sequence and run
+     * them concurrently. They will make observations of the types that
+     * ought only to be possible definitely after each is Python-ready.
+     * Each will note the high-resolution time at which it began and was
+     * able to complete its first action, and complete its other
+     * actions.
+     */
+    @BeforeAll
+    static void setUpClass() {
+        // Ensure the type system exists
+        assertTrue(TypeSystem.bootstrapNanoTime > 0L,
+                "Check type system booted");
+        // Match the number of cases. (We keep adding to them.)
+        final int NCASES = 2;
+        // Create NTHREADS choosing which action comes first.
+        for (int i = 0; i < NTHREADS; i++) {
+            int k = i % NCASES;
+            threads.add(switch (k) {
+                case 0 -> new AccessThread(k) {
+                    @Override
+                    void action() throws Throwable {
+                        type = MyList.TYPE;
+                        String name = "a" + tid;
+                        Abstract.setAttr(type, name, k);
+                        attrsAdded.put(name, k);
+                    }
+                };
+
+                case 1 -> new AccessThread(k) {
+                    @Override
+                    void action() throws Throwable {
+                        type = MyList2.TYPE;
+                        String name = "b" + tid;
+                        Abstract.setAttr(type, name, k);
+                        attrsAdded.put(name, k);
+                    }
+                };
+
+                // --------------- not used from here: see NCASES
+
+                case 2 -> new AccessThread(k) {
+                    @Override
+                    void action() { type = PyBaseException.TYPE; }
+                };
+
+                default -> new AccessThread(k) {
+                    @Override
+                    void action() { type = PyObject.TYPE; }
+                };
+            });
+        }
+
+        // Create a barrier of matching capacity.
+        barrier = new CyclicBarrier(threads.size());
+
+        // Start the threads in a shuffled order.
+        Collections.shuffle(threads, random);
+        logger.info("{} threads prepared.", threads.size());
+        for (Thread t : threads) { t.start(); }
+
+        // Wait for the threads to finish.
+        for (Thread t : threads) {
+            try {
+                t.join(1000);
+            } catch (InterruptedException e) {
+                // Check completion later
+            }
+        }
+
+        // Make sure they all stop (so the test does).
+        boolean allStopped = true;
+        for (Thread t : threads) { allStopped &= hasStopped(t); }
+        assertTrue(allStopped, "Threads were still running");
+
+        // Now sort them by the time the first action completed
+        Comparator<AccessThread> byFirst = new Comparator<>() {
+
+            @Override
+            public int compare(AccessThread t1, AccessThread t2) {
+                return Long.compare(t1.firstNanoTime, t2.firstNanoTime);
+            }
+        };
+        Collections.sort(threads, byFirst);
+
+        // Make the winning thread the reference time for the test
+        referenceNanoTime = threads.get(0).firstNanoTime;
+        for (AccessThread at : threads) {
+            at.subtractTime(referenceNanoTime);
+        }
+
+        // Dump the thread times by start time.
+        if (truthy(DUMP_PROPERTY)) { dumpThreads(); }
+    }
+
+    /** Property is defined and nothing like "false". */
+    private static boolean truthy(String property) {
+        property = System.getProperty(property, "false").toLowerCase();
+        return !"false".equals(property);
+    }
+
+    /**
+     * Dump (relative) bootstrap time and thread times to standard
+     * output.
+     */
+    private static void dumpThreads() {
+        for (AccessThread t : threads) { System.out.println(t); }
+    }
+
+    private static boolean hasStopped(Thread t) {
+        if (t.isAlive()) {
+            logger.warn("Still running {}", t.getName());
+            // t.stop();
+            return false;
+        }
+        return true;
+    }
+
+    /** All threads completed. */
+    @SuppressWarnings("static-method")
+    @Test
+    @DisplayName("All threads complete")
+    void allComplete() {
+        long completed = threads.stream()
+                .filter(t -> t.finishNanoTime > 0L).count();
+        assertTrue(completed == threads.size(),
+                () -> String.format("%d threads did not complete.",
+                        threads.size() - completed));
+    }
+
+    /** Some threads started before the first action completed. */
+    @SuppressWarnings("static-method")
+    @Test
+    @DisplayName("A race takes place")
+    void aRaceTookPlace() {
+        // Enough relative start times should be negative
+        long competitors = threads.stream()
+                .filter(t -> t.startNanoTime <= 0L).count();
+        logger.info("{} threads were racing.", competitors);
+        assertFalse(competitors < MIN_THREADS, () -> String
+                .format("Detect < %d competitors.", MIN_THREADS));
+    }
+
+    /** All the threads saw a ready state on their type. */
+    @SuppressWarnings("static-method")
+    @Test
+    @DisplayName("All threads see their type ready")
+    void readyState() {
+        for (AccessThread at : threads) {
+            assertTrue(at.ready, "Check READY");
+        }
+    }
+
+    /** All the threads see the final feature flags. */
+    @SuppressWarnings("static-method")
+    @Test
+    @DisplayName("All threads see the final feature flags")
+    void finalFeatures() {
+        for (AccessThread at : threads) {
+            PyType t = at.type;
+            assertEquals(t.getFeatures(), at.features);
+        }
+    }
+
+    /**
+     * All the threads saw method "__repr__" when it was looked up
+     * during the race.
+     *
+     * @throws PyAttributeError if attribute lookup fails
+     * @throws Throwable if something else goes wrong
+     */
+    @SuppressWarnings("static-method")
+    @Test
+    @DisplayName("__repr__ seen if present")
+    void checkRepr() throws PyAttributeError, Throwable {
+        for (AccessThread at : threads) {
+            PyType t = at.type;
+            /*
+             * Failure here is a sign that this thread was allowed a
+             * lookup (see otherActions()) before t was Python ready.
+             */
+            assertSame(t.lookup("__repr__"), at.reprMethod,
+                    "check '__repr__' was seen");
+        }
+    }
+
+    /**
+     * All the threads saw method "__call__" when it was looked up
+     * during the race.
+     *
+     * @throws PyAttributeError if attribute lookup fails
+     * @throws Throwable if something else goes wrong
+     */
+    @SuppressWarnings("static-method")
+    @Test
+    @DisplayName("__call__ seen if present")
+    void checkCall() throws PyAttributeError, Throwable {
+        for (AccessThread at : threads) {
+            PyType t = at.type;
+            /*
+             * Failure here is a sign that this thread was allowed a
+             * lookup (see otherActions()) before t was Python ready.
+             */
+            assertSame(t.lookup("__call__"), at.callMethod,
+                    "check '__call__' was seen");
+        }
+    }
+
+    /**
+     * All the threads saw methods "foo" and "bar", where they exist for
+     * the type, when they were looked up during the race.
+     *
+     * @throws PyAttributeError if attribute lookup fails
+     * @throws Throwable if something else goes wrong
+     */
+    @SuppressWarnings("static-method")
+    @Test
+    @DisplayName("foo and bar are seen if present")
+    void checkFooBar() throws PyAttributeError, Throwable {
+        for (AccessThread at : threads) {
+            PyType t = at.type;
+            /*
+             * Failure here is a sign that this thread was allowed a
+             * lookup (see otherActions()) before t was Python ready.
+             */
+            assertSame(t.lookup("foo"), at.fooMethod,
+                    "check 'foo' was seen");
+            assertSame(t.lookup("bar"), at.barMethod,
+                    "check 'bar' was seen");
+        }
+    }
+
+    /**
+     * All the threads see attributes added to a given type by every
+     * thread that referenced it.
+     *
+     * @throws PyAttributeError if attribute lookup fails
+     * @throws Throwable if something else goes wrong
+     */
+    @SuppressWarnings("static-method")
+    @Test
+    @DisplayName("Attributes added by any thread are present")
+    void checkAttrs() throws PyAttributeError, Throwable {
+        for (AccessThread at : threads) {
+            for (Entry<String, Object> e : at.attrsAdded.entrySet()) {
+                assertSame(e.getValue(),
+                        Abstract.getAttr(at.type, e.getKey()));
+            }
+        }
+    }
+
+    /**
+     * A thread that performs actions on the types, so that we may test
+     * the outcome is the same for all threads. We keep track of times
+     * in nanoseconds so we can be sure of the order of events. All
+     * times will be adjusted relative to the earliest
+     * {@link #firstNanoTime} so that they are reasonably printable.
+     */
+    static abstract class AccessThread extends Thread {
+        /** Time this thread started. */
+        long startNanoTime;
+        /** Time this thread completed {@code action()}. */
+        long firstNanoTime;
+        /** Time this thread completed {@code otherActions()}. */
+        long finishNanoTime;
+        /** The value seen in {@code TYPE}. */
+        PyType type;
+        /** Attribute name suffix unique-ish to thread. */
+        final String tid;
+        /** Attribute names added by this thread to its type. */
+        final Map<String, Object> attrsAdded = new HashMap<>();
+
+        /** Type was ready when inspected. */
+        boolean ready;
+        /** Type features (flags) when inspected. */
+        EnumSet<TypeFlag> features;
+        /** Attribute "_repr__" when inspected. */
+        Object reprMethod;
+        /** Attribute "__call__" when inspected. */
+        Object callMethod;
+        /** Attribute "foo" when inspected. */
+        Object fooMethod;
+        /** Attribute "bar" when inspected. */
+        Object barMethod;
+
+        /**
+         * Create a {@code Thread} to run. We specialise this with a
+         * specific definition of {@link #action()}.
+         *
+         * @param choice of type for this thread
+         */
+        AccessThread(int choice) {
+            this.tid = String.format("_%03d",
+                    Thread.currentThread().getId() % 1000L);
+        }
+
+        /**
+         * Each implementation of {@code InitThread} retrieves the same
+         * data, but chooses to do one action first by overriding this
+         * method. {@link #otherActions()} then completes the work.
+         *
+         * @throws Throwable from failing API calls
+         */
+        abstract void action() throws Throwable;
+
+        @Override
+        public void run() {
+            // Wait at the barrier until every thread arrives.
+            try {
+                barrier.await();
+                // sleep(random.nextInt(3) * 1000);
+            } catch (InterruptedException | BrokenBarrierException e) {
+                // This shouldn't happen.
+                fail("A thread was interrupted at the barrier.");
+                return;
+            }
+            // Perform the action: *raw* nanos before and after.
+            startNanoTime = System.nanoTime();
+            try {
+                action();
+            } catch (Throwable e) {
+                logger.atWarn().setMessage("action() threw {}")
+                        .addArgument(e).log();
+            }
+            firstNanoTime = System.nanoTime();
+            otherActions();
+            finishNanoTime = System.nanoTime();
+        }
+
+        /** The required actions apart from the one already done. */
+        void otherActions() {
+            BaseType t = (BaseType)type;
+            ready = t.hasFeature(KernelTypeFlag.READY);
+            features = t.getFeatures();
+            fooMethod = t.lookup("foo");
+        }
+
+        /**
+         * Adjust times backwards by the given amount.
+         *
+         * @param ref to subtract from each recorded nanosecond time
+         */
+        void subtractTime(long ref) {
+            startNanoTime -= ref;
+            firstNanoTime -= ref;
+            finishNanoTime -= ref;
+        }
+
+        @Override
+        public String toString() {
+            String fmt =
+                    "%20s  start=%10.4f, first=%10.4f, finish=%10.4f (%5dns)";
+            return String.format(fmt, type.getName(),
+                    startNanoTime * 1e-6, firstNanoTime * 1e-6,
+                    finishNanoTime * 1e-6,
+                    finishNanoTime - firstNanoTime);
+        }
+    }
+
+    /** A user-defined type */
+    private static class MyList extends PyList {
+        final static PyType TYPE = PyType
+                .fromSpec(new TypeSpec("MyList", MethodHandles.lookup())
+                        .base(PyList.TYPE));
+
+        @PythonMethod
+        int foo() { return 1; }
+    }
+
+    /** A user-defined type */
+    private static class MyList2 extends MyList {
+        final static PyType TYPE = PyType.fromSpec(
+                new TypeSpec("MyList2", MethodHandles.lookup())
+                        .base(MyList.TYPE));
+
+        @Override
+        @PythonMethod
+        int foo() { return 42; }
+
+        @PythonMethod
+        double bar(int i) { return 10.0 * foo(); }
+    }
+}

--- a/rt4core/src/test/java/uk/co/farowl/vsj4/runtime/TypeConcurrencyTest.java
+++ b/rt4core/src/test/java/uk/co/farowl/vsj4/runtime/TypeConcurrencyTest.java
@@ -2,21 +2,15 @@
 // Licensed to PSF under a contributor agreement.
 package uk.co.farowl.vsj4.runtime;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import java.lang.invoke.MethodHandles;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.EnumSet;
-import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Random;
-import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
@@ -25,44 +19,34 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import uk.co.farowl.vsj4.runtime.Exposed.PythonMethod;
-import uk.co.farowl.vsj4.runtime.kernel.BaseType;
-import uk.co.farowl.vsj4.runtime.kernel.KernelTypeFlag;
-
 /**
- * This is a variant of {@link BootstrapTest} focusing on competition to
- * create and use non-bootstrap types in Java. We test that when threads
- * create (and therefore publish) types they are either Python-ready
- * from the start or properly protected by locks that block attribute
- * access.
+ * This test modifies the attributes of some (mutable) type objects and
+ * reads those attributes, or performs operations dependent on them,
+ * concurrently from distinct threads. It will look for (and fail on)
+ * outcomes we deem impossible.
  * <p>
- * We shall start a lot of threads, as close to simultaneously as we can
- * manage, that each access a type that the type system will not have
- * been seen before.
+ * Unusually for JUnit tests, the intense processing takes place during
+ * {@link #setUpClass()}, and the individual JUnit tests are predicates
+ * on a list of lists of violations collected on during that time. If
+ * the list is empty, that's a pass.
  * <p>
- * We have each thread make observation and attempt operations on the
- * type that should be consistent with that type's final state. The
- * thread race occurs during {@link #setUpClass()}. Tests (JUnit tests)
- * run after the threads become joined, and take arbitrarily long, so
- * they have to operate on observations made "hot" during the race.
+ * A significant conceptual challenge is to define the expected or
+ * disallowed behaviours. Python has only recently started to allow true
+ * concurrency without the GIL and the required behaviours are not yet
+ * clearly stated (2025). Java guarantees "sequentially consistent"
+ * execution of correctly synchronised programs. The tests here are
+ * (deliberately) <b>not</b> correctly synchronised in the test region.
+ * The hypothesis we attempt to disprove by testing is that
+ * unsynchronised use from Python of the objects we provide leads to
+ * behaviour not expected of Python.
  * <p>
- * Each thread records when it started and when it got its answer. For a
- * satisfactory test, multiple threads should be racing before the first
- * thread completes its first action so we have a genuine race. (This is
- * less likely on hosts with few CPUs.)
- *
- * @implNote A comparison of tabulated times for this test run in
- *     isolation (in an IDE, say) and in bulk regression tests (under
- *     Gradle, say) will show a substantial difference in the time
- *     elapsed between thread start and first action complete. During
- *     this time, a type has to be constructed (e.g.
- *     {@link MyList#type}). In an isolated test, this includes creating
- *     the base type (here {@code list}), whereas in the batch tests it
- *     tends to exist already. Do not including pre-existing types as
- *     actual thread targets since their threads may complete without
- *     racing.
+ * This test is influenced by the literature on the "litmus tests", used
+ * to test or complement assertions made for a processor architecture
+ * and to validate language memory models. Listing 16.1 in <i>Java
+ * Concurrency in Practice</i>, Peierls, Goetz, et al. is an example of
+ * the latter.
  */
-@DisplayName("When multiple threads publish type objects")
+@DisplayName("When multiple threads access type objects")
 @TestMethodOrder(MethodOrderer.MethodName.class)
 class TypeConcurrencyTest {
 
@@ -70,37 +54,17 @@ class TypeConcurrencyTest {
     static final Logger logger =
             LoggerFactory.getLogger(TypeConcurrencyTest.class);
 
-    /** Threads in total. &gt;&gt; {@code setUpClass().NCASES} */
-    static final int NTHREADS = 20;
+    /** Threads in each batch. */
+    static final int BATCH_SIZE = 20; // ~100
 
-    /** If defined, dump the times recorded by threads. */
-    static final String DUMP_PROPERTY =
-            "uk.co.farowl.vsj4.runtime.TypeConcurrencyTest.times";
+    /** Number of batches. */
+    static final int BATCH_COUNT = 100; // ~ 10000
 
-    /**
-     * Check this many threads actually concurrent. Ideally
-     * &gt;{@code setUpClass().NCASES} but expectation depends on CPUs.
-     */
-    static int MIN_THREADS =
-            Math.min(Runtime.getRuntime().availableProcessors(),
-                    NTHREADS) / 2;
+    /** Curtail the test when we have found this many failures. */
+    static final int FAILURE_LIMIT = BATCH_SIZE + 5;
 
-    /** Random (or deterministic) order. */
-    static final long seed = System.currentTimeMillis();
-    // static final long seed = 12345L; // Somewhat repeatable
-
-    /** Threads to run. */
-    static final List<AccessThread> threads = new ArrayList<>();
-    /** A barrier they all wait behind. */
-    static CyclicBarrier barrier;
-    /** Source of random behaviour. */
-    static Random random = new Random(seed);
-
-    /** Time the {@link #barrierNanoTime} triggered thread starts. */
-    static long barrierNanoTime;
-
-    /** Time the first thread completed its first action. */
-    static long refNanoTime;
+    /** Failing litmus tests */
+    static List<LitmusTest> failures = new LinkedList<>();
 
     /**
      * We create multiple threads for each behavioural sequence and run
@@ -111,401 +75,252 @@ class TypeConcurrencyTest {
      * actions.
      */
     @BeforeAll
-    static void setUpClass() {
+    static void setUpClass() throws Throwable {
+
         // Ensure the type system exists
         assertTrue(TypeSystem.bootstrapNanoTime > 0L,
                 "Check type system booted");
-        // Match the number of cases. (We keep adding to them.)
-        final int NCASES = 2;
-        // Create NTHREADS choosing which action comes first.
-        for (int i = 0; i < NTHREADS; i++) {
-            int k = i % NCASES;
-            threads.add(switch (k) {
-                case 0 -> new AccessThread(k, MyList.class) {
-                    @Override
-                    void action() throws Throwable {
-                        type = MyList.TYPE;
-                        String name = "a" + tid;
-                        Abstract.setAttr(type, name, k);
-                        attrsAdded.put(name, k);
-                    }
-                };
 
-                case 1 -> new AccessThread(k, MyList2.class) {
-                    @Override
-                    void action() throws Throwable {
-                        type = MyList2.TYPE;
-                        String name = "b" + tid;
-                        Abstract.setAttr(type, name, k);
-                        attrsAdded.put(name, k);
-                    }
-                };
+        // Batch of tests to run concurrently.
+        LitmusTest[] tests = new LitmusTest[BATCH_SIZE];
+        Thread[] threads = new Thread[BATCH_SIZE];
 
-                // --------------- not used from here: see NCASES.
-                // See implNote concerning pre-existing types.
-
-                case 2 -> new AccessThread(k, PyNameError.class) {
-                    @Override
-                    void action() { type = PyNameError.TYPE; }
-                };
-
-                default -> new AccessThread(k, PyObject.class) {
-                    @Override
-                    void action() { type = PyObject.TYPE; }
-                };
-            });
+        for (int i = 0; i < BATCH_SIZE; i++) {
+            tests[i] = new SBLitmusTest();
         }
 
-        // Create a barrier of matching capacity.
-        barrier = new CyclicBarrier(threads.size(),
-                () -> barrierNanoTime = System.nanoTime());
+        logger.debug("TypeConcurrencyTest begun");
 
-        // Start the threads in a shuffled order.
-        Collections.shuffle(threads, random);
-        logger.info("{} threads prepared.", threads.size());
-        for (Thread t : threads) { t.start(); }
-
-        // Wait for the threads to finish.
-        for (Thread t : threads) {
-            try {
-                t.join(1000);
-            } catch (InterruptedException e) {
-                // Check completion later
+        // We use that storage repeatedly with new tests.
+        for (int batch = 0; batch < BATCH_COUNT; batch++) {
+            // Create threads: each will run a pair of racing threads.
+            for (int i = 0; i < BATCH_SIZE; i++) {
+                threads[i] = new Thread(tests[i]);
             }
-        }
+            // Start them all close together in time
+            for (Thread t : threads) { t.start(); }
 
-        // Make sure they all stop (so the test does).
-        boolean allStopped = true;
-        for (Thread t : threads) { allStopped &= hasStopped(t); }
-        assertTrue(allStopped, "Threads were still running");
-
-        // Now sort them by the time the first action completed
-        Comparator<AccessThread> byFirst = new Comparator<>() {
-
-            @Override
-            public int compare(AccessThread t1, AccessThread t2) {
-                return Long.compare(t1.firstNanoTime, t2.firstNanoTime);
+            // Wait for the threads to finish.
+            for (int i = 0; i < BATCH_SIZE; i++) {
+                try {
+                    threads[i].join(1000);
+                } catch (InterruptedException e) {
+                    // Check completion later
+                }
+                // Collect failures in a list.
+                LitmusTest test = tests[i];
+                if (test.failed()) {
+                    failures.add(test);
+                    tests[i] = new SBLitmusTest();
+                } else {
+                    test.reset();
+                }
             }
-        };
-        Collections.sort(threads, byFirst);
 
-        // Make the winning thread the reference time for the test
-        refNanoTime = threads.get(0).firstNanoTime;
-        for (AccessThread at : threads) {
-            at.subtractTime(refNanoTime);
+            // Make sure they all stop (so the test does).
+            boolean allStopped = true;
+            for (Thread t : threads) { allStopped &= hasStopped(t); }
+            assertTrue(allStopped, "Threads were still running");
+
+            // Early exit if ample evidence.
+            if (failures.size() >= FAILURE_LIMIT) { break; }
         }
-
-        // Dump the thread times by start time.
-        // TODO Make dump conditional again (once test reliable on CI)
-        // if (truthy(DUMP_PROPERTY)) { dumpThreads(); }
-        dumpThreads();
     }
 
-    /** Property is defined and nothing like "false". */
-    private static boolean truthy(String property) {
-        property = System.getProperty(property, "false").toLowerCase();
-        return !"false".equals(property);
-    }
-
-    /**
-     * Dump (relative) bootstrap time and thread times to standard
-     * output.
-     */
-    private static void dumpThreads() {
-        double r = (TypeSystem.readyNanoTime - refNanoTime) * 1e-6;
-        String fmt = "%42s   =%10.4f  (relative ms)\n";
-        System.out.printf(fmt, "Type system ready at", r);
-        for (AccessThread t : threads) { System.out.println(t); }
+    @AfterAll
+    static void tearDownClass() {
+        logger.debug("TypeConcurrencyTest complete");
     }
 
     private static boolean hasStopped(Thread t) {
         if (t.isAlive()) {
             logger.warn("Still running {}", t.getName());
-            // t.stop();
             return false;
         }
         return true;
     }
 
-    /** All threads completed. */
+    /** Check for tests that ended with an exceptions. */
     @SuppressWarnings("static-method")
     @Test
-    @DisplayName("All threads complete")
-    void allComplete() {
-        long completed = threads.stream()
-                .filter(t -> t.finishNanoTime > 0L).count();
-        assertTrue(completed == threads.size(),
-                () -> String.format("%d threads did not complete.",
-                        threads.size() - completed));
-    }
-
-    /** Enough threads started before the first action completed. */
-    @SuppressWarnings("static-method")
-    @Test
-    @DisplayName("A race takes place")
-    void aRaceTookPlace() {
-        // Enough relative start times should be negative
-        long competitors = threads.stream()
-                .filter(t -> t.startNanoTime <= 0L).count();
-        logger.info(
-                "{} threads were racing. (Min {} on this platform.)",
-                competitors, MIN_THREADS);
-        assertFalse(competitors < MIN_THREADS, () -> String
-                .format("Detect < %d competitors.", MIN_THREADS));
-    }
-
-    /** All the threads saw a ready state on their type. */
-    @SuppressWarnings("static-method")
-    @Test
-    @DisplayName("All threads see their type ready")
-    void readyState() {
-        for (AccessThread at : threads) {
-            assertTrue(at.ready, "Check READY");
+    @DisplayName("No exceptions were thrown")
+    void checkException() {
+        for (LitmusTest t : failures) {
+            assertNull(t.exc1,
+                    () -> String.format("thread t1 threw %s", t.exc1));
+            assertNull(t.exc2,
+                    () -> String.format("thread t2 threw %s", t.exc2));
         }
     }
 
-    /** All the threads see the final feature flags. */
+    /** Check the outcome was allowed. */
     @SuppressWarnings("static-method")
     @Test
-    @DisplayName("All threads see the final feature flags")
-    void finalFeatures() {
-        for (AccessThread at : threads) {
-            PyType t = at.type;
-            assertEquals(t.getFeatures(), at.features);
+    @DisplayName("Only allowed states were reached")
+    void checkAllowed() throws PyAttributeError, Throwable {
+        for (LitmusTest t : failures) {
+            if (!t.allowed()) { fail(t.toString()); }
         }
     }
 
     /**
-     * All the threads saw method "__repr__" when it was looked up
-     * during the race.
-     *
-     * @throws PyAttributeError if attribute lookup fails
-     * @throws Throwable if something else goes wrong
+     * A test object that runs two threads defined by the methods
+     * {@link #t1()} and {@link #t2()} in a race. The test object itself
+     * implements {@link Runnable} so that we can run many copies in
+     * parallel (for efficiency and to stress the processor), but it is
+     * the pair of threads in each case that constitute the test, or the
+     * effective litmus test {@code program}.
+     * <p>
+     * A subclass defines {@link #t1()}, {@link #t2()} and
+     * {@link #allowed()} to define the activity and determine whether
+     * the outcome is allowed (a pass) for not (a fail).
      */
-    @SuppressWarnings("static-method")
-    @Test
-    @DisplayName("__repr__ is seen")
-    void checkRepr() throws PyAttributeError, Throwable {
-        for (AccessThread at : threads) {
-            PyType t = at.type;
-            /*
-             * Failure here is a sign that this thread was allowed a
-             * lookup (see otherActions()) before t was Python ready.
-             */
-            assertSame(t.lookup("__repr__"), at.reprMethod,
-                    () -> "check '__repr__' in " + t.getName());
-        }
-    }
+    abstract static class LitmusTest implements Runnable {
 
-    /**
-     * All the threads saw method "__call__" when it was looked up
-     * during the race.
-     *
-     * @throws PyAttributeError if attribute lookup fails
-     * @throws Throwable if something else goes wrong
-     */
-    @SuppressWarnings("static-method")
-    @Test
-    @DisplayName("__call__ is seen")
-    void checkCall() throws PyAttributeError, Throwable {
-        for (AccessThread at : threads) {
-            PyType t = at.type;
-            /*
-             * Failure here is a sign that this thread was allowed a
-             * lookup (see otherActions()) before t was Python ready.
-             */
-            assertSame(t.lookup("__call__"), at.callMethod,
-                    () -> "check '__call__' in " + t.getName());
-        }
-    }
+        private CyclicBarrier barrier = new CyclicBarrier(2);
 
-    /**
-     * All the threads saw methods "foo" and "bar", where they exist for
-     * the type, when they were looked up during the race.
-     *
-     * @throws PyAttributeError if attribute lookup fails
-     * @throws Throwable if something else goes wrong
-     */
-    @SuppressWarnings("static-method")
-    @Test
-    @DisplayName("foo and bar are seen if present")
-    void checkFooBar() throws PyAttributeError, Throwable {
-        for (AccessThread at : threads) {
-            PyType t = at.type;
-            /*
-             * Failure here is a sign that this thread was allowed a
-             * lookup (see otherActions()) before t was Python ready.
-             */
-            assertSame(t.lookup("foo"), at.fooMethod,
-                    () -> "check 'foo' in " + t.getName());
-            assertSame(t.lookup("bar"), at.barMethod,
-                    () -> "check 'bar' in " + t.getName());
-        }
-    }
+        /** Any exception thrown in the corresponding method. */
+        Throwable exc1, exc2;
 
-    /**
-     * All the threads see attributes added to a given type by every
-     * thread that referenced it.
-     *
-     * @throws PyAttributeError if attribute lookup fails
-     * @throws Throwable if something else goes wrong
-     */
-    @SuppressWarnings("static-method")
-    @Test
-    @DisplayName("Attributes added by any thread are present")
-    void checkAttrs() throws PyAttributeError, Throwable {
-        for (AccessThread at : threads) {
-            for (Entry<String, Object> e : at.attrsAdded.entrySet()) {
-                assertSame(e.getValue(),
-                        Abstract.getAttr(at.type, e.getKey()));
-            }
-        }
-    }
+        /** Define the actions of the first thread. */
+        abstract void t1() throws Throwable;
 
-    /**
-     * A thread that performs actions on the types, so that we may test
-     * the outcome is the same for all threads. We keep track of times
-     * in nanoseconds so we can be sure of the order of events. All
-     * times will be adjusted relative to the earliest
-     * {@link #firstNanoTime} so that they are reasonably printable.
-     */
-    static abstract class AccessThread extends Thread {
-        /** The primary class of the type this thread addresses. */
-        final Class<?> klass;
-
-        /** Time this thread started. */
-        long startNanoTime;
-        /** Time this thread completed {@code action()}. */
-        long firstNanoTime;
-        /** Time this thread completed {@code otherActions()}. */
-        long finishNanoTime;
-        /** Attribute name suffix unique-ish to thread. */
-        final String tid;
-        /** Attribute names added by this thread to its type. */
-        final Map<String, Object> attrsAdded = new HashMap<>();
-
-        /** The value seen in {@code TYPE}. */
-        PyType type;
-        /** Type was ready when inspected. */
-        boolean ready;
-        /** Type features (flags) when inspected. */
-        EnumSet<TypeFlag> features;
-        /** Attribute "_repr__" when inspected. */
-        Object reprMethod;
-        /** Attribute "__call__" when inspected. */
-        Object callMethod;
-        /** Attribute "foo" when inspected. */
-        Object fooMethod;
-        /** Attribute "bar" when inspected. */
-        Object barMethod;
+        /** Define the actions of the second thread. */
+        abstract void t2() throws Throwable;
 
         /**
-         * Create a {@code Thread} to run. We specialise this with a
-         * specific definition of {@link #action()}. Providing a
-         * reference to a class here does <i>not</i> statically
-         * initialise it.
-         *
-         * @param choice of type for this thread
+         * Test whether the result of the pair of threads is allowed
+         * behaviour (a pass) for not (a fail).
          */
-        AccessThread(int choice, Class<?> klass) {
-            this.klass = klass;
-            this.tid = String.format("_%03d",
-                    Thread.currentThread().getId() % 1000L);
-        }
+        abstract boolean allowed();
 
         /**
-         * Each implementation of {@code InitThread} retrieves the same
-         * data, but chooses to do one action first by overriding this
-         * method. {@link #otherActions()} then completes the work.
-         *
-         * @throws Throwable from failing API calls
+         * Create a test consisting of two threads ready to be started,
+         * one to call {@link #t1()} and the other {@link #t2()}. When
+         * started by <code>this.{@link #run()}</code>, both threads
+         * wait at a barrier of capacity two, meaning the first waits
+         * and until the second arrives there, then both proceed to call
+         * their respective methods in a race. Afterwards,
+         * {@link #allowed()} determines whether the state reached is an
+         * allowed one.
          */
-        abstract void action() throws Throwable;
+        LitmusTest() {}
 
+        /**
+         * Run the two threads set up by the constructor and wait for
+         * both to complete.
+         *
+         */
         @Override
         public void run() {
-            // Wait at the barrier until every thread arrives.
-            try {
-                barrier.await();
-                // sleep(random.nextInt(3) * 1000);
-            } catch (InterruptedException | BrokenBarrierException e) {
-                // This shouldn't happen.
-                fail("A thread was interrupted at the barrier.");
-                return;
-            }
-            /*
-             * Perform the action: recording *raw* nanos before and
-             * after. On small platforms, as well as MIN_THREADS being
-             * small, we may have to use the barrier time as the
-             * effective start time to weaken the race test.
-             */
-            startNanoTime = MIN_THREADS < 4 ? barrierNanoTime
-                    : System.nanoTime();
-            try {
-                action();
-            } catch (Throwable e) {
-                logger.atWarn().setMessage("action() threw {}")
-                        .addArgument(e).log();
-            }
-            firstNanoTime = System.nanoTime();
-            otherActions();
-            finishNanoTime = System.nanoTime();
-        }
 
-        /** The required actions apart from the one already done. */
-        void otherActions() {
-            BaseType t = (BaseType)type;
-            ready = t.hasFeature(KernelTypeFlag.READY);
-            features = t.getFeatures();
-            reprMethod = t.lookup("__repr__");
-            callMethod = t.lookup("__call__");
-            fooMethod = t.lookup("foo");
-            barMethod = t.lookup("bar");
+            // This thread calls t1()
+            Thread call_t1 = new Thread(() -> {
+                try {
+                    barrier.await();
+                    t1();
+                } catch (Throwable t) {
+                    exc1 = t;
+                }
+            });
+
+            // At the same time, this thread calls t2()
+            Thread call_t2 = new Thread(() -> {
+                try {
+                    barrier.await();
+                    t2();
+                } catch (Throwable t) {
+                    exc2 = t;
+                }
+            });
+
+            Thread[] threads = {call_t1, call_t2};
+
+            // Start both threads. (They sync at the barrier.)
+            for (Thread t : threads) { t.start(); }
+            // Wait for the threads to finish.
+            for (Thread t : threads) {
+                try {
+                    t.join(1000);
+                } catch (InterruptedException e) {
+                    // Check completion later
+                    exc1 = exc2 = e;
+                }
+            }
         }
 
         /**
-         * Adjust times backwards by the given amount.
-         *
-         * @param ref to subtract from each recorded nanosecond time
+         * Return true if there was an exception of allowed is false.
          */
-        void subtractTime(long ref) {
-            startNanoTime -= ref;
-            firstNanoTime -= ref;
-            finishNanoTime -= ref;
+        boolean failed() {
+            return exc1 != null || exc2 != null || !allowed();
+        }
+
+        /**
+         * Return the test to initial conditions to save creating a
+         * fresh one. Only define this if that can be validly done.
+         */
+        @SuppressWarnings("static-method")
+        void reset() { fail("reset() not supported"); }
+    }
+
+    /**
+     * The Storage Buffering litmus test interpreted for a type object
+     * name space as the "store". We add attributes in a race and test
+     * for a sequentially consistent result.
+     * <p>
+     * The test shows that the updates to a type object are published
+     * between threads as if execution were sequentially consistent.
+     */
+    static class SBLitmusTest extends LitmusTest {
+        PyType type;
+        Object r1, r2;
+
+        SBLitmusTest() throws Throwable {
+            this.type = (PyType)PyType.TYPE().call("SBType",
+                    Py.tuple(PyObject.TYPE), Py.dict());
+        }
+
+        @Override
+        void t1() throws Throwable {
+            r1 = Abstract.lookupAttr(type, "A");
+            Abstract.setAttr(type, "B", 2);
+        }
+
+        @Override
+        void t2() throws Throwable {
+            r2 = Abstract.lookupAttr(type, "B");
+            Abstract.setAttr(type, "A", 1);
+        }
+
+        @Override
+        boolean allowed() {
+            // Sequentially consistent answer.
+            return r1 == null && r2 == null  //
+                    || r1 == null && r2.equals(2)  //
+                    || r1.equals(1) && r2 == null;
+        }
+
+        @Override
+        void reset() {
+            r1 = r2 = null;
+            exc1 = exc2 = null;
+            try {
+                if (Abstract.lookupAttr(type, "A") != null) {
+                    Abstract.delAttr(type, "A");
+                }
+                if (Abstract.lookupAttr(type, "B") != null) {
+                    Abstract.delAttr(type, "B");
+                }
+            } catch (Throwable e) {
+                fail("Unable to reset() type attributes");
+            }
         }
 
         @Override
         public String toString() {
-            String fmt =
-                    "%20s  start=%10.4f, first=%10.4f, finish=%10.4f (%5dns)";
-            return String.format(fmt, type.getName(),
-                    startNanoTime * 1e-6, firstNanoTime * 1e-6,
-                    finishNanoTime * 1e-6,
-                    finishNanoTime - firstNanoTime);
+            return String.format("SBLitmusTest [type=%s, r1=%s, r2=%s]",
+                    type, r1, r2);
         }
-    }
-
-    /** A user-defined type */
-    private static class MyList extends PyList {
-        final static PyType TYPE = PyType
-                .fromSpec(new TypeSpec("MyList", MethodHandles.lookup())
-                        .base(PyList.TYPE));
-
-        @PythonMethod
-        int foo() { return 1; }
-    }
-
-    /** A user-defined type */
-    private static class MyList2 extends MyList {
-        final static PyType TYPE = PyType.fromSpec(
-                new TypeSpec("MyList2", MethodHandles.lookup())
-                        .base(MyList.TYPE));
-
-        @Override
-        @PythonMethod
-        int foo() { return 42; }
-
-        @PythonMethod
-        double bar(int i) { return 10.0 * foo(); }
     }
 }

--- a/rt4core/src/test/java/uk/co/farowl/vsj4/runtime/TypeExposerSlotWrapperTest.java
+++ b/rt4core/src/test/java/uk/co/farowl/vsj4/runtime/TypeExposerSlotWrapperTest.java
@@ -132,7 +132,7 @@ class TypeExposerSlotWrapperTest {
         void expect(SpecialMethod slot) {
             assertEquals(slot, descr.sm);
             assertEquals(slot.methodName, descr.__name__());
-            assertEquals(PyWrapperDescr.TYPE, descr.getType());
+            assertEquals(PyWrapperDescr.TYPE(), descr.getType());
             assertEquals(ExampleObject.TYPE, descr.__objclass__());
         }
 


### PR DESCRIPTION
It is not clear that the type system bootstrap process is really bullet-proof, or quite how it extends to defining (and mutating) other types. These seem to be related.

It is difficult to avoid type objects becoming visible when they are not Python ready. If we can't manage that, then the incomplete types have to be able to defend themselves with locks.

This will be a series of changes meant to clarify the guarantees that have to be given and to honour them.